### PR TITLE
feat: 상품 이미지 파일 업로드 기능 구현

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Item.java
+++ b/src/main/java/shop/tryit/domain/item/Item.java
@@ -40,13 +40,13 @@ public class Item extends BaseTimeEntity {
     private Category category; // 상품 카테고리 [DOG, CAT]
 
     @OneToOne(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, REMOVE})
-    private ItemImage mainImage; // 상품 메인이미지
+    private ItemFile mainImage; // 상품 메인이미지
 
     @OneToMany(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, REMOVE})
-    private List<ItemImage> detailImage = new ArrayList<>(); // 상품 상세이미지
+    private List<ItemFile> detailImage = new ArrayList<>(); // 상품 상세이미지
 
     @Builder
-    private Item(String name, int price, int stockQuantity, Category category, ItemImage mainImage, List<ItemImage> detailImage) {
+    private Item(String name, int price, int stockQuantity, Category category, ItemFile mainImage, List<ItemFile> detailImage) {
         this.name = name;
         this.price = price;
         this.stockQuantity = stockQuantity;

--- a/src/main/java/shop/tryit/domain/item/ItemFile.java
+++ b/src/main/java/shop/tryit/domain/item/ItemFile.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class ItemImage {
+public class ItemFile {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -30,13 +30,13 @@ public class ItemImage {
     @JoinColumn(name = "item_id")
     private Item item;
 
-    private ItemImage(String originFileName, String storeFileName) {
+    private ItemFile(String originFileName, String storeFileName) {
         this.originFileName = originFileName;
         this.storeFileName = storeFileName;
     }
 
-    public ItemImage of(String originFileName, String storeFileName) {
-        return new ItemImage(originFileName, storeFileName);
+    public static ItemFile of(String originFileName, String storeFileName) {
+        return new ItemFile(originFileName, storeFileName);
     }
 
 }

--- a/src/main/java/shop/tryit/domain/item/ItemFileStore.java
+++ b/src/main/java/shop/tryit/domain/item/ItemFileStore.java
@@ -1,0 +1,61 @@
+package shop.tryit.domain.item;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class ItemFileStore {
+
+    @Value("${custom.path.upload-images}")
+    private String filePath;
+
+    public String getFullPath(String fileName) {
+        return filePath + fileName;
+    }
+
+    public ItemFile storeMainImage(MultipartFile multipartFile) throws IOException {
+        if (multipartFile.isEmpty()) {
+            return null;
+        }
+
+        String originFileName = multipartFile.getOriginalFilename();
+        String storeFileName = createStoreFileName(originFileName);
+        multipartFile.transferTo(new File(getFullPath(storeFileName)));
+        return ItemFile.of(originFileName, storeFileName);
+    }
+
+    public List<ItemFile> storeDetailImages(List<MultipartFile> multipartFiles) throws IOException {
+        List<ItemFile> storeDetailImagesResult = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            if (!multipartFile.isEmpty()) {
+                storeDetailImagesResult.add(storeMainImage(multipartFile));
+            }
+        }
+        return storeDetailImagesResult;
+    }
+
+    /**
+     * storeFileName 생성
+     * ex) image.png -> uuid.png
+     */
+    private String createStoreFileName(String originFileName) {
+        String ext = extracted(originFileName); // 파일 확장자
+        String uuid = UUID.randomUUID().toString(); // 서버에 저장될 이름
+        return uuid + "." + ext;
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String extracted(String originFileName) {
+        int pos = originFileName.lastIndexOf(".");
+        return originFileName.substring(pos + 1);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+
+custom:
+  path:
+#    upload-images: C:/Users/anneu/Desktop/study/team-project/tryit/src/main/resources/static/img/item/


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 상품 이미지 파일 업로드 기능 구현

## 📋 작업사항
- 클라이언트 ➡ 상품 메인 이미지 1장, 상품 상세 이미지 여러장 업로드 가능
- 서버 ➡ 업로드된 파일명을 uuid를 사용해 중복이 없도록 변환해서 저장
- 파일 업로드 경로는 추후 변경이 필요