### PR TITLE
refactor: 상품 카테고리 enum 타입으로 변경

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Category.java
+++ b/src/main/java/shop/tryit/domain/item/Category.java
@@ -1,33 +1,7 @@
 package shop.tryit.domain.item;
 
-import static javax.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
+public enum Category {
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Entity
-@Getter
-@NoArgsConstructor(access = PROTECTED)
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "category_id")
-    private Long id; // 카테고리 식별자
-
-    private String name; // 카테고리명 [CAT, DOG]
-
-    private Category(String name) {
-        this.name = name;
-    }
-
-    public static Category from(String name) {
-        return new Category(name);
-    }
+    CAT, DOG
 
 }

--- a/src/main/java/shop/tryit/domain/item/Item.java
+++ b/src/main/java/shop/tryit/domain/item/Item.java
@@ -2,6 +2,7 @@ package shop.tryit.domain.item;
 
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.CascadeType.REMOVE;
+import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -10,10 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.Builder;
@@ -35,8 +35,7 @@ public class Item extends BaseTimeEntity {
     private int price; // 상품 가격
     private int stockQuantity; // 상품 재고
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "category_id")
+    @Enumerated(STRING)
     private Category category; // 상품 카테고리 [DOG, CAT]
 
     @OneToOne(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, REMOVE})

--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import shop.tryit.domain.item.Category;
 import shop.tryit.domain.item.Item;
 import shop.tryit.domain.item.ItemFile;
 import shop.tryit.domain.item.ItemFileStore;
@@ -26,7 +27,11 @@ public class ItemController {
 
     @GetMapping("/new")
     public String newItemForm(Model model) {
+        Category[] categories = Category.values();
+
         model.addAttribute("item", ItemFormDto.builder().build());
+        model.addAttribute("categories", categories);
+
         return "/items/register";
     }
 

--- a/src/main/resources/templates/items/register.html
+++ b/src/main/resources/templates/items/register.html
@@ -16,8 +16,12 @@
 
         <div class="form-group">
           <label th:for="category">카테고리</label>
-          <input type="radio" th:field="*{category}" th:value="CAT"> Cat
-          <input type="radio" th:field="*{category}" th:value="DOG"> Dog
+            <select class="form-select" th:field="*{category}">
+              <option value="">== 카테고리 선택 ==</option>
+              <option th:each="category : ${categories}"
+                      th:value="${category}"
+                      th:text="${category}">CAT</option>
+            </select>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 카테고리를 엔티티에서 enum으로 변경

## 📋 작업사항
- Category를 엔티티에서 enum 타입으로 변경
- 상품과 카테고리간 연관관계 매핑 제거 ➡ Enumerated로 수정
- 상품 컨트롤러에서 카테고리 리스트를 뷰로 넘겨주는 과정 추가
- 뷰(register.html)에서 카테고리를 뿌려주는 방법을 radio에서 select 형식으로 변경