### PR TITLE
refactor: 상품 파일 엔티티 구조 변경 

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Item.java
+++ b/src/main/java/shop/tryit/domain/item/Item.java
@@ -7,7 +7,6 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,7 +14,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,20 +36,16 @@ public class Item extends BaseTimeEntity {
     @Enumerated(STRING)
     private Category category; // 상품 카테고리 [DOG, CAT]
 
-    @OneToOne(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, REMOVE})
-    private ItemFile mainImage; // 상품 메인이미지
-
     @OneToMany(mappedBy = "item", fetch = LAZY, cascade = {PERSIST, REMOVE})
-    private List<ItemFile> detailImage = new ArrayList<>(); // 상품 상세이미지
+    private List<ItemFile> images; // 상품 이미지
 
     @Builder
-    private Item(String name, int price, int stockQuantity, Category category, ItemFile mainImage, List<ItemFile> detailImage) {
+    private Item(String name, int price, int stockQuantity, Category category, List<ItemFile> images) {
         this.name = name;
         this.price = price;
         this.stockQuantity = stockQuantity;
         this.category = category;
-        this.mainImage = mainImage;
-        this.detailImage = detailImage;
+        this.images = images;
     }
 
     public void update(String name, int price, int stockQuantity, Category category) {
@@ -75,6 +69,11 @@ public class Item extends BaseTimeEntity {
 
     private void changeCategory(Category category) {
         this.category = category;
+    }
+
+    public void addImage(ItemFile itemFile) {
+        itemFile.setItem(this);
+        images.add(itemFile);
     }
 
 }

--- a/src/main/java/shop/tryit/domain/item/ItemFile.java
+++ b/src/main/java/shop/tryit/domain/item/ItemFile.java
@@ -1,11 +1,13 @@
 package shop.tryit.domain.item;
 
+import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -26,17 +28,25 @@ public class ItemFile {
     private String originFileName; // 원본 파일명
     private String storeFileName;  // 서버에 저장되는 파일명
 
+    @Enumerated(STRING)
+    private ItemFileType type;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 
-    private ItemFile(String originFileName, String storeFileName) {
+    private ItemFile(String originFileName, String storeFileName, ItemFileType type) {
         this.originFileName = originFileName;
         this.storeFileName = storeFileName;
+        this.type = type;
     }
 
-    public static ItemFile of(String originFileName, String storeFileName) {
-        return new ItemFile(originFileName, storeFileName);
+    public static ItemFile of(String originFileName, String storeFileName, ItemFileType type) {
+        return new ItemFile(originFileName, storeFileName, type);
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
     }
 
 }

--- a/src/main/java/shop/tryit/domain/item/ItemFileStore.java
+++ b/src/main/java/shop/tryit/domain/item/ItemFileStore.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -32,7 +30,7 @@ public class ItemFileStore {
         return getFilePath() + fileName;
     }
 
-    public ItemFile storeMainImage(MultipartFile multipartFile) throws IOException {
+    public ItemFile storeItemFile(MultipartFile multipartFile, ItemFileType type) throws IOException {
         if (multipartFile.isEmpty()) {
             return null;
         }
@@ -40,17 +38,7 @@ public class ItemFileStore {
         String originFileName = multipartFile.getOriginalFilename();
         String storeFileName = createStoreFileName(originFileName);
         multipartFile.transferTo(new File(getFullPath(storeFileName)));
-        return ItemFile.of(originFileName, storeFileName);
-    }
-
-    public List<ItemFile> storeDetailImages(List<MultipartFile> multipartFiles) throws IOException {
-        List<ItemFile> storeDetailImagesResult = new ArrayList<>();
-        for (MultipartFile multipartFile : multipartFiles) {
-            if (!multipartFile.isEmpty()) {
-                storeDetailImagesResult.add(storeMainImage(multipartFile));
-            }
-        }
-        return storeDetailImagesResult;
+        return ItemFile.of(originFileName, storeFileName, type);
     }
 
     /**

--- a/src/main/java/shop/tryit/domain/item/ItemFileType.java
+++ b/src/main/java/shop/tryit/domain/item/ItemFileType.java
@@ -1,0 +1,7 @@
+package shop.tryit.domain.item;
+
+public enum ItemFileType {
+
+    MAIN, DETAIL
+
+}

--- a/src/main/java/shop/tryit/web/item/ItemAdapter.java
+++ b/src/main/java/shop/tryit/web/item/ItemAdapter.java
@@ -1,0 +1,28 @@
+package shop.tryit.web.item;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import shop.tryit.domain.item.Item;
+import shop.tryit.domain.item.ItemFile;
+
+public class ItemAdapter {
+
+    public static Item toEntity(ItemFormDto form, ItemFile mainImage, ItemFile detailImage) throws IOException {
+        List<ItemFile> itemImages = new ArrayList<>();
+
+        Item item = Item.builder()
+                .name(form.getName())
+                .price(form.getPrice())
+                .category(form.getCategory())
+                .stockQuantity(form.getStockQuantity())
+                .images(itemImages)
+                .build();
+
+        item.addImage(mainImage);
+        item.addImage(detailImage);
+
+        return item;
+    }
+
+}

--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -1,7 +1,9 @@
 package shop.tryit.web.item;
 
+import static shop.tryit.domain.item.ItemFileType.DETAIL;
+import static shop.tryit.domain.item.ItemFileType.MAIN;
+
 import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -39,18 +41,10 @@ public class ItemController {
     public String newItem(@ModelAttribute("item") ItemFormDto form) throws IOException {
         log.info("saved item name = {}", form.getName());
 
-        ItemFile mainImage = itemFileStore.storeMainImage(form.getMainImage());
-        List<ItemFile> detailImages = itemFileStore.storeDetailImages(form.getDetailImage());
+        ItemFile mainImage = itemFileStore.storeItemFile(form.getMainImage(), MAIN);
+        ItemFile detailImage = itemFileStore.storeItemFile(form.getDetailImage(), DETAIL);
 
-        // DB에 저장
-        Item item = Item.builder()
-                .name(form.getName())
-                .category(form.getCategory())
-                .stockQuantity(form.getStockQuantity())
-                .price(form.getPrice())
-                .mainImage(mainImage)
-                .detailImage((detailImages))
-                .build();
+        Item item = ItemAdapter.toEntity(form, mainImage, detailImage);
 
         itemService.register(item);
 

--- a/src/main/java/shop/tryit/web/item/ItemFormDto.java
+++ b/src/main/java/shop/tryit/web/item/ItemFormDto.java
@@ -2,7 +2,6 @@ package shop.tryit.web.item;
 
 import static lombok.AccessLevel.PROTECTED;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,10 +22,10 @@ public class ItemFormDto {
 
     private MultipartFile mainImage;
 
-    private List<MultipartFile> detailImage;
+    private MultipartFile detailImage;
 
     @Builder
-    private ItemFormDto(String name, Integer price, Integer stockQuantity, Category category, MultipartFile mainImage, List<MultipartFile> detailImage) {
+    private ItemFormDto(String name, Integer price, Integer stockQuantity, Category category, MultipartFile mainImage, MultipartFile detailImage) {
         this.name = name;
         this.price = price;
         this.stockQuantity = stockQuantity;

--- a/src/main/resources/templates/items/register.html
+++ b/src/main/resources/templates/items/register.html
@@ -46,7 +46,7 @@
 
         <div class="form-group">
           <label th:for="mainImage">상세 이미지</label>
-          <input type="file" th:field="*{detailImage}" class="form-control" multiple="multiple">
+          <input type="file" th:field="*{detailImage}" class="form-control">
         </div>
 
         <button type="submit" class="btn btn-primary">등록</button>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 상품 이미지 파일(ItemFile) 엔티티 구조 변경에 따른 리팩토링

## 📋 작업사항
- 상품(Item) 엔티티의 메인이미지, 상세 이미지 필드를 상품 이미지라는 하나의 필드로 관리하도록 변경
- 상품 파일(ItemFile) 엔티티에 type 필드를 추가해 enum 타입(MAIN, DETAIL)으로 해당 이미지 파일의 용도를 명시
- 사용자는 상세 이미지 파일을 1개만 업로드 가능하도록 변경
- 컨트롤러에 있던 DTO->엔티티 로직을 ItemAdapter로 분리