### PR TITLE
 feat: 상품 수정 개발

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Image.java
+++ b/src/main/java/shop/tryit/domain/item/Image.java
@@ -50,4 +50,10 @@ public class Image {
         this.item = item;
     }
 
+    public void update(Image newImage) {
+        this.originFileName = newImage.getOriginFileName();
+        this.storeFileName = newImage.getStoreFileName();
+        this.type = newImage.getType();
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/item/ImageService.java
+++ b/src/main/java/shop/tryit/domain/item/ImageService.java
@@ -36,6 +36,36 @@ public class ImageService {
     }
 
     /**
+     * 메인 이미지 조회
+     */
+    public Image getMainImage(Long id) {
+        Item item = itemService.findOne(id); // 같은 트랜잭션 안에서 진행하기 위함
+
+        Image mainImage = null;
+
+        for (Image image : item.getImages())
+            if (image.getType()==MAIN)
+                mainImage = image;
+
+        return mainImage;
+    }
+
+    /**
+     * 상세 이미지 조회
+     */
+    public Image getDetailImage(Long id) {
+        Item item = itemService.findOne(id); // 같은 트랜잭션 안에서 진행하기 위함
+
+        Image detailImage = null;
+
+        for (Image image : item.getImages())
+            if (image.getType()==DETAIL)
+                detailImage = image;
+
+        return detailImage;
+    }
+
+    /**
      * 메인 이미지 목록 조회
      */
     public List<Image> findMainImages() {

--- a/src/main/java/shop/tryit/domain/item/ImageService.java
+++ b/src/main/java/shop/tryit/domain/item/ImageService.java
@@ -86,4 +86,62 @@ public class ImageService {
         return mainImages;
     }
 
+    /**
+     * 메인 이미지 수정
+     */
+    @Transactional
+    public Image updateMainImage(long id, ItemFormDto form) throws IOException {
+        log.info("======== 메인 이미지 수정 시작 ========");
+
+        Image findMainImage = getMainImage(id); // 기존 메인 이미지를 찾아옴
+
+        log.info("old 메인이미지 = {} , {}", findMainImage.getOriginFileName(), findMainImage.getStoreFileName());
+
+        // 새로 넘어온 이미지가 없을 경우 수정 사항 x
+        if (!form.getMainImage().isEmpty()) {
+            imageStore.deleteImageFile(findMainImage.getStoreFileName()); // 기존 메인 이미지 삭제
+            Image newMainImage = uploadMainImage(form); // 새로운 메인 이미지 서버에 저장
+            findMainImage.update(newMainImage); // 메인 이미지 정보 업데이트
+
+            log.info("new 메인이미지 = {}, {}", newMainImage.getOriginFileName(), newMainImage.getStoreFileName());
+            log.info("======== 메인 이미지 수정 종료 ========");
+
+            return newMainImage;
+        } else {
+            log.info("변경 없음");
+            log.info("======== 메인 이미지 수정 종료 ========");
+
+            return findMainImage;
+        }
+    }
+
+    /**
+     * 상세 이미지 수정
+     */
+    @Transactional
+    public Image updateDetailImage(long id, ItemFormDto form) throws IOException {
+        log.info("======== 상세 이미지 수정 시작 ========");
+
+        Image findDetailImage = getDetailImage(id); // 기존 상세 이미지를 찾아옴
+
+        log.info("old 상세이미지 = {} , {}", findDetailImage.getOriginFileName(), findDetailImage.getStoreFileName());
+
+        // 새로 넘어온 이미지가 있을 경우 기존에 있던 이미지 삭제 후 업로드
+        if (!form.getDetailImage().isEmpty()) {
+            imageStore.deleteImageFile(findDetailImage.getStoreFileName()); // 기존 상세 이미지 삭제
+            Image newDetailImage = uploadDetailImage(form); // 새로운 상세 이미지 서버에 저장
+            findDetailImage.update(newDetailImage); // 상세 이미지 정보 업데이트
+
+            log.info("new 상세이미지 = {}, {}", newDetailImage.getOriginFileName(), newDetailImage.getStoreFileName());
+            log.info("======== 상세 이미지 수정 종료 ========");
+
+            return newDetailImage;
+        } else {
+            log.info("변경 없음");
+            log.info("======== 상세 이미지 수정 종료 ========");
+
+            return findDetailImage;
+        }
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/item/ImageStore.java
+++ b/src/main/java/shop/tryit/domain/item/ImageStore.java
@@ -42,6 +42,15 @@ public class ImageStore {
     }
 
     /**
+     * 이미지 파일 삭제
+     */
+    public void deleteImageFile(String storeFileName) throws IOException {
+        // TODO : 서버에 삭제할 이미지가 없는 경우 예외 처리 필요
+        File file = new File(getFullPath(storeFileName));
+        file.delete();
+    }
+
+    /**
      * storeFileName 생성
      * ex) image.png -> uuid.png
      */

--- a/src/main/java/shop/tryit/domain/item/ItemService.java
+++ b/src/main/java/shop/tryit/domain/item/ItemService.java
@@ -37,7 +37,10 @@ public class ItemService {
         return itemRepository.findAll();
     }
 
-    private Item findOne(Long itemId) {
+    /**
+     * 특정 상품 조회
+     */
+    public Item findOne(Long itemId) {
         return itemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalStateException("해당 상품을 찾을 수 없습니다."));
     }

--- a/src/main/java/shop/tryit/web/item/ItemAdapter.java
+++ b/src/main/java/shop/tryit/web/item/ItemAdapter.java
@@ -22,6 +22,17 @@ public class ItemAdapter {
         return item;
     }
 
+    public static Item toEntity(ItemFormDto form) {
+        Item item = Item.builder()
+                .name(form.getName())
+                .price(form.getPrice())
+                .category(form.getCategory())
+                .stockQuantity(form.getStockQuantity())
+                .build();
+
+        return item;
+    }
+
     public static ItemUpdateDto toDto(Item item, Image mainImage, Image detailImage) {
         ItemUpdateDto updateDto = ItemUpdateDto.builder()
                 .name(item.getName())

--- a/src/main/java/shop/tryit/web/item/ItemAdapter.java
+++ b/src/main/java/shop/tryit/web/item/ItemAdapter.java
@@ -22,6 +22,19 @@ public class ItemAdapter {
         return item;
     }
 
+    public static ItemUpdateDto toDto(Item item, Image mainImage, Image detailImage) {
+        ItemUpdateDto updateDto = ItemUpdateDto.builder()
+                .name(item.getName())
+                .price(item.getPrice())
+                .stockQuantity(item.getStockQuantity())
+                .category(item.getCategory())
+                .mainImage(mainImage)
+                .detailImage(detailImage)
+                .build();
+
+        return updateDto;
+    }
+
     public static List<ItemListDto> toListDto(List<Item> items, List<Image> mainImages) {
         List<ItemListDto> toListDtoResult = new ArrayList<>();
 

--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -71,4 +71,19 @@ public class ItemController {
         return "/items/update";
     }
 
+    @PostMapping("/{id}/update")
+    public String update(@PathVariable long id, @ModelAttribute("item") ItemFormDto form) throws IOException {
+        log.info("======== 상품 수정 컨트롤러 실행 ========");
+
+        Item newItem = ItemAdapter.toEntity(form);
+
+        itemService.update(id, newItem);
+        imageService.updateMainImage(id, form);
+        imageService.updateDetailImage(id, form);
+
+        log.info("======== 상품 수정 컨트롤러 종료 ========");
+
+        return "redirect:/items";
+    }
+
 }

--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import shop.tryit.domain.item.Category;
@@ -58,5 +59,16 @@ public class ItemController {
         return "/items/list";
     }
 
+    @GetMapping("/{id}/update")
+    public String updateForm(@PathVariable long id, Model model) {
+        Category[] categories = Category.values();
+        model.addAttribute("categories", categories);
+
+        Item item = itemService.findOne(id);
+        ItemUpdateDto itemUpdateDto = ItemAdapter.toDto(item, imageService.getMainImage(id), imageService.getDetailImage(id));
+        model.addAttribute("item", itemUpdateDto);
+
+        return "/items/update";
+    }
 
 }

--- a/src/main/java/shop/tryit/web/item/ItemUpdateDto.java
+++ b/src/main/java/shop/tryit/web/item/ItemUpdateDto.java
@@ -1,0 +1,37 @@
+package shop.tryit.web.item;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import shop.tryit.domain.item.Category;
+import shop.tryit.domain.item.Image;
+
+@Data
+@NoArgsConstructor(access = PROTECTED)
+public class ItemUpdateDto {
+
+    private String name;
+
+    private Integer price;
+
+    private Integer stockQuantity;
+
+    private Category category;
+
+    private Image mainImage;
+
+    private Image detailImage;
+
+    @Builder
+    private ItemUpdateDto(String name, Integer price, Integer stockQuantity, Category category, Image mainImage, Image detailImage) {
+        this.name = name;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.category = category;
+        this.mainImage = mainImage;
+        this.detailImage = detailImage;
+    }
+
+}

--- a/src/main/resources/templates/items/update.html
+++ b/src/main/resources/templates/items/update.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+
+<head th:replace="fragments/header :: header"></head>
+
+<body>
+  <!-- ======= Header ======= -->
+  <div th:replace="fragments/body-header :: body-header" id="header" class="fixed-top d-flex align-items-center"></div>
+
+  <!-- ======= Hero Section ======= -->
+  <section id="hero">
+    <div class="container">
+      <form th:action th:object="${item}" method="post" enctype="multipart/form-data">
+
+        <div class="form-group">
+          <label th:for="category">카테고리</label>
+          <select class="form-select" th:field="*{category}">
+            <option th:each="category : ${categories}"
+                    th:value="${category}"
+                    th:text="${category}">CAT
+            </option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label th:for="name">상품명</label>
+          <input type="text" th:field="*{name}" class="form-control" placeholder="이름을 입력하세요">
+        </div>
+
+        <div>
+          <label th:for="price">가격</label>
+          <input type="text" th:field="*{price}" class="form-control" placeholder="가격을 입력하세요">
+        </div>
+
+        <div class="form-group">
+          <label th:for="stockQuantity">재고</label>
+          <input type="text" th:field="*{stockQuantity}" class="form-control" placeholder="재고를 입력하세요">
+        </div>
+
+        <div class="form-group">
+          <label th:for="mainImage">메인 이미지</label>
+          <input type="file" th:field="*{mainImage}" class="form-control">
+          <img th:src="|/files/*{mainImage.getStoreFileName()}|" width="100" height="100"/>
+          <p th:text="*{mainImage.getOriginFileName()}">메인 이미지 파일명</p>
+        </div>
+
+        <div class="form-group">
+          <label th:for="mainImage">상세 이미지</label>
+          <input type="file" th:field="*{detailImage}" class="form-control">
+          <img th:src="|/files/*{detailImage.getStoreFileName()}|" width="100" height="100"/>
+          <p th:text="*{detailImage.getOriginFileName()}">상세 이미지 파일명</p>
+        </div>
+
+        <button type="submit" class="btn btn-secondary">수정하기</button>
+        <a th:href="@{/items}" class="btn btn-dark" role="button">목록으로</a>
+
+      </form>
+    </div> <!-- /container -->
+  </section> <!-- End Hero -->
+
+  <!-- ======= Footer ======= -->
+  <div th:replace="fragments/footer :: footer"></div>
+</body>
+
+</html>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 상품 수정 관련 개발

## 📋 작업사항
- domain
   - 기존 서버에 저장되어 있던 이미지 파일을 삭제하는 로직 추가
   - DB에 보관되는 상품 이미지 정보 수정을 위해 상품 엔티티에 `update` 기능 추가
   - 상품 이미지 서비스 (ImageService)
      - 상품의 메인, 상세 이미지를 수정하는 서비스 로직 추가
      - 상품의 메인, 상세 이미지를 조회해오는 서비스 로직 추가

- web
   - 상품 수정용 DTO 생성 (ItemUpdateDto)
   - `상품 엔티티` ➡ `상품 수정 DTO`로 변환해주는 어댑터 기능 추가
   - 상품 수정 뷰 생성
   - 상품 수정 관련 컨트롤러 구현
