### PR TITLE
feat: 주문 관련 서비스 구현(단건 주문 서비스)

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Item.java
+++ b/src/main/java/shop/tryit/domain/item/Item.java
@@ -76,4 +76,16 @@ public class Item extends BaseTimeEntity {
         images.add(image);
     }
 
+    public void addStock(int quantity) {
+        this.stockQuantity += quantity;
+    }
+
+    public void removeStock(int quantity) {
+        int restStock = this.stockQuantity - quantity;
+        if (restStock < 0) {
+            throw new NotEnoughStockException("주문한 수량이 재고수량보다 많습니다.");
+        }
+        this.stockQuantity = restStock;
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/item/NotEnoughStockException.java
+++ b/src/main/java/shop/tryit/domain/item/NotEnoughStockException.java
@@ -1,0 +1,19 @@
+package shop.tryit.domain.item;
+
+public class NotEnoughStockException extends RuntimeException {
+    public NotEnoughStockException() {
+    }
+
+    public NotEnoughStockException(String message) {
+        super(message);
+    }
+
+    public NotEnoughStockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotEnoughStockException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/shop/tryit/domain/order/Order.java
+++ b/src/main/java/shop/tryit/domain/order/Order.java
@@ -58,4 +58,11 @@ public class Order extends BaseTimeEntity {
         return new Order(member, orderNum, status);
     }
 
+    /**
+     * 주문 취소
+     */
+    public void cancel(OrderStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/order/OrderDetail.java
+++ b/src/main/java/shop/tryit/domain/order/OrderDetail.java
@@ -47,4 +47,15 @@ public class OrderDetail {
         return new OrderDetail(item, order, orderTotalPrice, count);
     }
 
+    /**
+     * 주문 취소
+     */
+    public void cancel() {
+        getItem().addStock(count);
+    }
+
+    public void itemRemoveStock() {
+        getItem().removeStock(count);
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/order/OrderService.java
+++ b/src/main/java/shop/tryit/domain/order/OrderService.java
@@ -1,0 +1,76 @@
+package shop.tryit.domain.order;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.tryit.domain.item.ItemRepository;
+import shop.tryit.domain.member.MemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderDetailRepository orderDetailRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    /**
+     * 주문 정보 저장
+     */
+    @Transactional
+    public Long register(Order order) {
+        return orderRepository.save(order);
+    }
+
+    /**
+     * 주문 상세 저장
+     */
+    @Transactional
+    public Long detailRegister(OrderDetail orderDetail) {
+        orderDetail.itemRemoveStock();
+        return orderDetailRepository.save(orderDetail);
+    }
+
+    /**
+     * 주문 1 건 검색
+     */
+    public Order findOne(Long id) {
+        return orderRepository.findById(id)
+                .orElseThrow(() -> new IllegalStateException("해당 주문을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 주문 상세 조회
+     */
+    public OrderDetail DetailFindOne(Long id) {
+        return orderDetailRepository.findById(id)
+                .orElseThrow(() -> new IllegalStateException("해당 주문 상품을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 주문 취소
+     */
+    @Transactional
+    public void cancel(Long orderId) {
+        Order cancelOrder = findOne(orderId);
+        cancelOrder.cancel(OrderStatus.CANCEL); //주문 정보의 주문상태를 CANCEL 로 변경
+
+        //단일 상품 주문 취소
+        OrderDetail cancelOrderDetail = DetailFindOne(orderId);
+        cancelOrderDetail.cancel();
+
+        // TODO 장바구니 주문 후 다량주문 취소일 경우 삭제 로직 리팩토링 예정
+//        //캔슬된 주문의 상세상품들 주문한 수량을 다시 돌려놓기
+//        List<OrderDetail> orderDetails = findAll(orderId);
+//        for (OrderDetail orderDetail : orderDetails) {
+//            orderDetail.cancel();
+//        }
+    }
+
+    /**
+     * 주문 목록
+     */
+
+}

--- a/src/test/java/shop/tryit/domain/order/OrderServiceTests.java
+++ b/src/test/java/shop/tryit/domain/order/OrderServiceTests.java
@@ -1,0 +1,94 @@
+package shop.tryit.domain.order;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import shop.tryit.domain.item.Item;
+import shop.tryit.domain.member.Member;
+import shop.tryit.repository.order.OrderDetailJpaRepository;
+import shop.tryit.repository.order.OrderJpaRepository;
+
+@Transactional
+@SpringBootTest
+class OrderServiceTests {
+
+    @Autowired
+    private OrderService sut;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderDetailJpaRepository orderDetailJpaRepository;
+
+    @Test
+    void 주문_저장() {
+        //given
+        Member member = Member.builder().build();
+        Order order = Order.of(member, OrderStatus.ORDER);
+
+        //when
+        Long savedId = sut.register(order);
+
+        //then
+        assertTrue(orderJpaRepository.findById(savedId).isPresent());
+    }
+
+    @Test
+    void 주문_상세_내역_저장() {
+        //given
+        Item item = Item.builder().stockQuantity(10).build();
+        Member member = Member.builder().build();
+        Order order = Order.of(member, OrderStatus.ORDER);
+        OrderDetail orderDetail = OrderDetail.of(item, order, 5000, 2);
+
+        //when
+        Long savedId = sut.detailRegister(orderDetail);
+
+        //then
+        assertTrue(orderDetailJpaRepository.findById(savedId).isPresent());
+        assertEquals("주문 후 재고는 주문수량만큼 줄어야 한다.", 8,
+                item.getStockQuantity());
+    }
+
+    @Test
+    void 주문_취소() {
+        //given
+        Item item = Item.builder().stockQuantity(8).build();
+        Member member = Member.builder().build();
+        Order order = Order.of(member, OrderStatus.ORDER);
+
+        Long savedId = orderJpaRepository.save(order).getId();
+        Order cancelOrder = sut.findOne(savedId);
+
+        //when1 : 주문정보 취소
+        cancelOrder.cancel(OrderStatus.CANCEL);
+
+        //then1 : 주문 상태 확인
+        assertEquals("주문 취소시 상태는 CANCEL 이다.", OrderStatus.CANCEL,
+                cancelOrder.getStatus());
+    }
+
+    @Test
+    void 주문_취소_재고_체크() {
+        //given
+        Item item = Item.builder().stockQuantity(8).build();
+        Member member = Member.builder().build();
+        Order order = Order.of(member, OrderStatus.CANCEL);
+        OrderDetail orderDetail = OrderDetail.of(item, order, 5000, 2);
+
+        //when
+        Long savedDetailId = orderDetailJpaRepository.save(orderDetail).getId();
+        OrderDetail cancelOrderDetail = sut.DetailFindOne(savedDetailId);
+        cancelOrderDetail.cancel();
+
+        //then2 : 주문수량 롤백확인
+        assertEquals("주문이 취소된 상품은 그만큼 재고가 증가해야 한다.", 10,
+                item.getStockQuantity());
+    }
+
+}


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 단건 주문 관련하여 서비스를 구현 하였습니다.

## 📋 작업사항
- 상품 엔티티에 재고 관리 메소드 추가
- 상품 재고 관리 시 발생 할 수 있는 에러 클래스 생성
- 주문 관련 엔티티에 주문 취소 관련 메소드 생성
- 주문 서비스 생성 
- 주문 서비스 테스트 생성