### PR TITLE
 feat: 상품 목록 검색, 페이징 처리

### DIFF
--- a/src/main/java/shop/tryit/domain/item/Image.java
+++ b/src/main/java/shop/tryit/domain/item/Image.java
@@ -56,4 +56,8 @@ public class Image {
         this.type = newImage.getType();
     }
 
+    public Long getItemId() {
+        return item.getId();
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/item/ItemRepository.java
+++ b/src/main/java/shop/tryit/domain/item/ItemRepository.java
@@ -2,6 +2,9 @@ package shop.tryit.domain.item;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import shop.tryit.web.item.ItemSearchDto;
 
 public interface ItemRepository {
 
@@ -12,5 +15,7 @@ public interface ItemRepository {
     List<Item> findAll();
 
     void delete(Item item);
+
+    Page<ItemSearchDto> searchItems(ItemSearchCondition condition, Pageable pageable);
 
 }

--- a/src/main/java/shop/tryit/domain/item/ItemSearchCondition.java
+++ b/src/main/java/shop/tryit/domain/item/ItemSearchCondition.java
@@ -1,0 +1,12 @@
+package shop.tryit.domain.item;
+
+import lombok.Getter;
+
+@Getter
+public class ItemSearchCondition {
+
+    private String name; // 상품 이름
+
+    private Category category; // 상품 카테고리 [DOG,CAT]
+
+}

--- a/src/main/java/shop/tryit/domain/item/ItemSearchCondition.java
+++ b/src/main/java/shop/tryit/domain/item/ItemSearchCondition.java
@@ -1,5 +1,6 @@
 package shop.tryit.domain.item;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -8,5 +9,11 @@ public class ItemSearchCondition {
     private String name; // 상품 이름
 
     private Category category; // 상품 카테고리 [DOG,CAT]
+
+    @Builder
+    private ItemSearchCondition(String name, Category category) {
+        this.name = name;
+        this.category = category;
+    }
 
 }

--- a/src/main/java/shop/tryit/domain/item/ItemService.java
+++ b/src/main/java/shop/tryit/domain/item/ItemService.java
@@ -2,8 +2,11 @@ package shop.tryit.domain.item;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.tryit.web.item.ItemSearchDto;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +55,13 @@ public class ItemService {
     public void delete(Long itemId) {
         Item item = findOne(itemId);
         itemRepository.delete(item);
+    }
+
+    /**
+     * 상품 검색
+     */
+    public Page<ItemSearchDto> searchItem(ItemSearchCondition condition, Pageable pageable) {
+        return itemRepository.searchItems(condition, pageable);
     }
 
 }

--- a/src/main/java/shop/tryit/repository/item/ItemCustom.java
+++ b/src/main/java/shop/tryit/repository/item/ItemCustom.java
@@ -1,0 +1,12 @@
+package shop.tryit.repository.item;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import shop.tryit.domain.item.ItemSearchCondition;
+import shop.tryit.web.item.ItemListDto;
+
+public interface ItemCustom {
+
+    Page<ItemListDto> searchItem(ItemSearchCondition condition, Pageable pageable);
+
+}

--- a/src/main/java/shop/tryit/repository/item/ItemCustom.java
+++ b/src/main/java/shop/tryit/repository/item/ItemCustom.java
@@ -3,10 +3,10 @@ package shop.tryit.repository.item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.tryit.domain.item.ItemSearchCondition;
-import shop.tryit.web.item.ItemListDto;
+import shop.tryit.web.item.ItemSearchDto;
 
 public interface ItemCustom {
 
-    Page<ItemListDto> searchItem(ItemSearchCondition condition, Pageable pageable);
+    Page<ItemSearchDto> searchItem(ItemSearchCondition condition, Pageable pageable);
 
 }

--- a/src/main/java/shop/tryit/repository/item/ItemCustom.java
+++ b/src/main/java/shop/tryit/repository/item/ItemCustom.java
@@ -7,6 +7,6 @@ import shop.tryit.web.item.ItemSearchDto;
 
 public interface ItemCustom {
 
-    Page<ItemSearchDto> searchItem(ItemSearchCondition condition, Pageable pageable);
+    Page<ItemSearchDto> searchItems(ItemSearchCondition condition, Pageable pageable);
 
 }

--- a/src/main/java/shop/tryit/repository/item/ItemCustomImpl.java
+++ b/src/main/java/shop/tryit/repository/item/ItemCustomImpl.java
@@ -32,7 +32,7 @@ public class ItemCustomImpl implements ItemCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ItemSearchDto> searchItem(ItemSearchCondition condition, Pageable pageable) {
+    public Page<ItemSearchDto> searchItems(ItemSearchCondition condition, Pageable pageable) {
         List<ItemSearchDto> itemSearchDtoList = searchContent(condition, pageable);
         injectMainImage(itemSearchDtoList);
         return PageableExecutionUtils.getPage(itemSearchDtoList, pageable, totalCount(condition)::fetchOne);

--- a/src/main/java/shop/tryit/repository/item/ItemCustomImpl.java
+++ b/src/main/java/shop/tryit/repository/item/ItemCustomImpl.java
@@ -1,0 +1,112 @@
+package shop.tryit.repository.item;
+
+import static shop.tryit.domain.item.QImage.image;
+import static shop.tryit.domain.item.QItem.item;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+import shop.tryit.domain.item.Category;
+import shop.tryit.domain.item.Image;
+import shop.tryit.domain.item.ImageType;
+import shop.tryit.domain.item.ItemSearchCondition;
+import shop.tryit.web.item.ItemSearchDto;
+import shop.tryit.web.item.QItemListDto;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemCustomImpl implements ItemCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ItemSearchDto> searchItem(ItemSearchCondition condition, Pageable pageable) {
+        List<ItemSearchDto> itemSearchDtoList = searchContent(condition, pageable);
+        injectMainImage(itemSearchDtoList);
+        return PageableExecutionUtils.getPage(itemSearchDtoList, pageable, totalCount(condition)::fetchOne);
+    }
+
+    /**
+     * 메인 이미지 주입
+     */
+    private void injectMainImage(List<ItemSearchDto> itemSearchDtoList) {
+        Map<Long, ItemSearchDto> map = itemSearchDtoList.stream()
+                .collect(Collectors.toMap(ItemSearchDto::getId, Function.identity()));
+
+        searchMainImage(map.keySet())
+                .forEach(image -> map.get(image.getItemId()).injectMainImage(image));
+    }
+
+    /**
+     * 총 검색 결과 개수
+     */
+    private JPAQuery<Long> totalCount(ItemSearchCondition condition) {
+        return queryFactory
+                .select(item.count())
+                .from(item)
+                .where(
+                        isContainName(condition.getName()),
+                        isContainCategory(condition.getCategory())
+                );
+    }
+
+    /**
+     * 상품 검색 결과 (메인 이미지 제외)
+     */
+    private List<ItemSearchDto> searchContent(ItemSearchCondition condition, Pageable pageable) {
+        QItemListDto qItemListDto = new QItemListDto(item.id, item.name, item.price);
+        return queryFactory
+                .select(qItemListDto)
+                .from(item)
+                .where(
+                        isContainName(condition.getName()),
+                        isContainCategory(condition.getCategory())
+                )
+                .orderBy(item.createDate.desc()) // 가장 최근 상품이 맨 앞으로 오도록 정렬
+                .limit(pageable.getPageSize())   // 한 페이지에 보여줄 갯수
+                .offset(pageable.getOffset())    // 어디서부터 보여줄 것인지
+                .fetch();
+    }
+
+    /**
+     * 상품 검색 결과 (메인 이미지)
+     */
+    private List<Image> searchMainImage(Collection<Long> itemIds) {
+        return queryFactory.selectFrom(image)
+                .where(
+                        image.type.eq(ImageType.MAIN),
+                        item.id.in(itemIds)
+                )
+                .join(image.item, item)
+                .fetch();
+    }
+
+    /**
+     * 상품 이름 검색 조건
+     */
+    private BooleanExpression isContainName(String name) {
+        // 상품 이름으로 검색 할 경우 포함하지 않으면 null 반환
+        return StringUtils.hasText(name) ? item.name.contains(name):null;
+    }
+
+    /**
+     * 상품 카테고리 검색 조건
+     */
+    private BooleanExpression isContainCategory(Category category) {
+        // 카테고리로 검색 할 경우 카테고리가 일치하지 않으면 null 반환
+        return Optional.ofNullable(category).isPresent() ? item.category.eq(category):null;
+    }
+
+}

--- a/src/main/java/shop/tryit/repository/item/ItemJpaRepository.java
+++ b/src/main/java/shop/tryit/repository/item/ItemJpaRepository.java
@@ -3,6 +3,6 @@ package shop.tryit.repository.item;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.tryit.domain.item.Item;
 
-public interface ItemJpaRepository extends JpaRepository<Item, Long> {
+public interface ItemJpaRepository extends JpaRepository<Item, Long>, ItemCustom {
 
 }

--- a/src/main/java/shop/tryit/repository/item/ItemRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/item/ItemRepositoryImpl.java
@@ -4,9 +4,13 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import shop.tryit.domain.item.Item;
 import shop.tryit.domain.item.ItemRepository;
+import shop.tryit.domain.item.ItemSearchCondition;
+import shop.tryit.web.item.ItemSearchDto;
 
 @Slf4j
 @Repository
@@ -34,6 +38,11 @@ public class ItemRepositoryImpl implements ItemRepository {
     @Override
     public void delete(Item item) {
         itemJpaRepository.delete(item);
+    }
+
+    @Override
+    public Page<ItemSearchDto> searchItems(ItemSearchCondition condition, Pageable pageable) {
+        return itemJpaRepository.searchItems(condition, pageable);
     }
 
 }

--- a/src/main/java/shop/tryit/web/item/ItemAdapter.java
+++ b/src/main/java/shop/tryit/web/item/ItemAdapter.java
@@ -32,22 +32,22 @@ public class ItemAdapter {
         return itemDto;
     }
 
-    public static List<ItemListDto> toDto(List<Item> items, List<Image> mainImages) {
-        List<ItemListDto> itemListDto = new ArrayList<>();
+    public static List<ItemSearchDto> toDto(List<Item> items, List<Image> mainImages) {
+        List<ItemSearchDto> itemSearchDtoList = new ArrayList<>();
 
-        // 조회된 모든 Item -> ItemListDto 변환해서 리스트에 담음
+        // 조회된 모든 Item -> ItemSearchDto 변환해서 리스트에 담음
         for (int i = 0; i < items.size(); i++) {
-            ItemListDto dto = ItemListDto.builder()
+            ItemSearchDto dto = ItemSearchDto.builder()
                     .id(items.get(i).getId())
                     .name(items.get(i).getName())
                     .price(items.get(i).getPrice())
                     .mainImage(mainImages.get(i))
                     .build();
 
-            itemListDto.add(dto);
+            itemSearchDtoList.add(dto);
         }
 
-        return itemListDto;
+        return itemSearchDtoList;
     }
 
 }

--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -71,9 +71,9 @@ public class ItemController {
 
         List<Image> mainImages = imageService.findMainImages();
 
-        List<ItemListDto> itemListDto = ItemAdapter.toDto(items, mainImages);
+        List<ItemSearchDto> itemSearchDtoList = ItemAdapter.toDto(items, mainImages);
 
-        model.addAttribute("items", itemListDto);
+        model.addAttribute("items", itemSearchDtoList);
 
         return "/items/list";
     }

--- a/src/main/java/shop/tryit/web/item/ItemSearchDto.java
+++ b/src/main/java/shop/tryit/web/item/ItemSearchDto.java
@@ -9,7 +9,7 @@ import shop.tryit.domain.item.Image;
 
 @Data
 @NoArgsConstructor(access = PROTECTED)
-public class ItemListDto {
+public class ItemSearchDto {
 
     private Long id;
 
@@ -20,7 +20,7 @@ public class ItemListDto {
     private Image mainImage;
 
     @Builder
-    private ItemListDto(Long id, String name, Integer price, Image mainImage) {
+    private ItemSearchDto(Long id, String name, Integer price, Image mainImage) {
         this.id = id;
         this.name = name;
         this.price = price;

--- a/src/main/java/shop/tryit/web/item/ItemSearchDto.java
+++ b/src/main/java/shop/tryit/web/item/ItemSearchDto.java
@@ -2,6 +2,7 @@ package shop.tryit.web.item;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,17 @@ public class ItemSearchDto {
         this.id = id;
         this.name = name;
         this.price = price;
+        this.mainImage = mainImage;
+    }
+
+    @QueryProjection
+    public ItemSearchDto(Long id, String name, Integer price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+
+    public void injectMainImage(Image mainImage) {
         this.mainImage = mainImage;
     }
 

--- a/src/test/java/shop/tryit/domain/item/ItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/item/ItemServiceTests.java
@@ -7,10 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
+import shop.tryit.web.item.ItemSearchDto;
 
 @Transactional
 @SpringBootTest
@@ -80,6 +84,30 @@ class ItemServiceTests {
         assertThatCode(() ->
                 sut.delete(savedId))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void 상품_검색() throws Exception {
+        // given
+        for (int i = 0; i < 50; i++) {
+            Item item = Item.builder()
+                    .name("item" + i)
+                    .build();
+            itemRepository.save(item);
+        }
+
+        ItemSearchCondition condition = ItemSearchCondition.builder()
+                .name("it")
+                .build();
+
+        PageRequest pageRequest = PageRequest.of(0, 5);
+
+        // when
+        Page<ItemSearchDto> itemSearchDtoPage = sut.searchItem(condition, pageRequest);
+        List<ItemSearchDto> contents = itemSearchDtoPage.getContent();
+
+        // then
+        Assertions.assertThat(contents.size()).isEqualTo(pageRequest.getPageSize());
     }
 
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 상품 목록 검색, 페이징 처리

## 📋 작업사항
- 상품 검색 조건 생성 (상품 이름, 상품 카테고리)
- 검색을 위한 상품 커스텀 레포지토리 인터페이스와 구현체 생성
- 상품 레포지토리에 상품 검색 기능 추가
- 상품 서비스 구현과 테스트 진행

- 리팩토링
  - 상품 목록 DTO 클래스명 변경 `ItemListDto` -> `ItemSearchDto`
  - 상품 검색 메소드명 변경 `searchItem` -> `searchItems`