### PR TITLE
feat: 상품 상세 폼에서 단건 주문 처리

### DIFF
--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -22,6 +22,7 @@ import shop.tryit.domain.item.Item;
 import shop.tryit.domain.item.ItemSearchCondition;
 import shop.tryit.domain.item.ItemSearchDto;
 import shop.tryit.domain.item.ItemService;
+import shop.tryit.web.order.OrderFormDto;
 
 @Slf4j
 @Controller
@@ -137,6 +138,7 @@ public class ItemController {
 
         ItemDto itemDto = ItemAdapter.toDto(item, imageService.getMainImage(id), imageService.getDetailImage(id));
         model.addAttribute("item", itemDto);
+        model.addAttribute("orderFormDto", OrderFormDto.builder().build());
 
         return "/items/detail";
     }

--- a/src/main/java/shop/tryit/web/order/OrderController.java
+++ b/src/main/java/shop/tryit/web/order/OrderController.java
@@ -33,10 +33,6 @@ public class OrderController {
     private final MemberService memberService;
     private final ItemService itemService;
 
-    /**
-     * 주문 정보 저장
-     * 단품 상세 저장
-     */
     @PostMapping("/new")
     public String newOrder(@Valid @ModelAttribute OrderFormDto orderFormDto,
                            BindingResult bindingResult,
@@ -51,7 +47,7 @@ public class OrderController {
         orderFormDto.setItemName(item.getName());
         orderFormDto.setItemPrice(item.getPrice());
 
-        //주문 상품이 단 건인 경우
+        //단건 주문인 경우
         int orderTotalPrice = orderFormDto.getItemPrice() * orderFormDto.getOrderQuantity();
         OrderDetail orderDetail = OrderAdapter.toEntity(orderFormDto, item, order, orderTotalPrice);
         orderService.detailRegister(orderDetail);

--- a/src/main/java/shop/tryit/web/order/OrderController.java
+++ b/src/main/java/shop/tryit/web/order/OrderController.java
@@ -38,7 +38,7 @@ public class OrderController {
      * 단품 상세 저장
      */
     @PostMapping("/new")
-    public String newOrder(@Valid @ModelAttribute("orderForDto") OrderFormDto orderFormDto,
+    public String newOrder(@Valid @ModelAttribute OrderFormDto orderFormDto,
                            BindingResult bindingResult,
                            @AuthenticationPrincipal User user) {
         Member member = memberService.findMember(user.getUsername());
@@ -48,6 +48,8 @@ public class OrderController {
         orderService.register(order);
 
         Item item = itemService.findOne(orderFormDto.getItemId());
+        orderFormDto.setItemName(item.getName());
+        orderFormDto.setItemPrice(item.getPrice());
 
         //주문 상품이 단 건인 경우
         int orderTotalPrice = orderFormDto.getItemPrice() * orderFormDto.getOrderQuantity();

--- a/src/main/java/shop/tryit/web/order/OrderFormDto.java
+++ b/src/main/java/shop/tryit/web/order/OrderFormDto.java
@@ -4,16 +4,19 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 상품상세에서 단건 주문을 했을 경우
+ */
 @Data
 @NoArgsConstructor
 public class OrderFormDto {
 
-    /**
-     * 상품상세에서 단품 주문을 했을 경우
-     */
+    // View에서 넘겨받는 값
     private Long itemId;
-    private String itemName;  //상품이름
     private int orderQuantity; //주문 수량
+
+    // DB에서 조회해오는 값
+    private String itemName;  //상품이름
     private int itemPrice; //상품 가격
 
     @Builder

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1249,19 +1249,35 @@ section {
   font-size: 16px;
 }
 
-.item-detail .order-info h4 {
-  display: inline-block;
-  margin-right: 15px;
+.item-detail tr {
+  width: 100px;
+}
+
+.item-detail tr > th {
+  font-weight: normal;
+  width: 102px;
+}
+
+.item-detail .order-info .quantity {
+  margin-top: 10px;
+}
+
+.item-detail .order-info .quantity label {
+  width: 100px;
+}
+
+.item-detail .order-info .quantity input {
+  /*border: none;*/
+  width: 50px;
   text-align: center;
 }
 
-.item-detail .order-info input {
-  border: none;
-  width: 40px;
-  color: mediumslateblue;
-  font-weight: 600;
-  text-align: center;
-  font-size: 18px;
+.item-detail .order-info .total-price {
+  margin-bottom: 20px;
+}
+
+.item-detail .order-info .total-price span {
+  font-weight: bold;
 }
 
 .item-detail .order-info .order-click {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1217,22 +1217,24 @@ section {
   margin-bottom: 20px;
 }
 
-.item-detail .item_img {
+.item-detail .item-img {
   text-align: center;
 }
 
-.item-detail .item_img img {
+.item-detail .item-img .main-img {
+  width: 400px;
+  height: 400px;
   /* width: 100%; */
 }
 
-.item-detail .item_info {
+.item-detail .item-info {
   padding-top: 30px;
   /* box-shadow: 0px 0 30px rgba(54, 65, 70, 0.08); */
 }
 
 .item-detail h2 {
-  font-size: 40px;
-  font-weight: 700;
+  font-size: 25px;
+  font-weight: 600;
   /* margin-bottom: 20px; */
   /* padding-bottom: 20px; */
   /* border-bottom: 1px solid #eee; */
@@ -1247,13 +1249,13 @@ section {
   font-size: 16px;
 }
 
-.item-detail .order_info h4 {
+.item-detail .order-info h4 {
   display: inline-block;
   margin-right: 15px;
   text-align: center;
 }
 
-.item-detail .order_info input {
+.item-detail .order-info input {
   border: none;
   width: 40px;
   color: mediumslateblue;
@@ -1262,8 +1264,14 @@ section {
   font-size: 18px;
 }
 
-.item-detail .order_info .order_click button {
-  width: 100%;
+.item-detail .order-info .order-click {
+  display: flex;
+  justify-content: end;
+  align-items: center;
+}
+
+.item-detail .order-info .order-click button {
+  width: 100px;
   margin-left: 15px;
 }
 

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -32,24 +32,25 @@
           </td>
         </table>
 
-        <form action="" method="post">
-          <div class="order-info">
+        <div class="order-info">
+          <form th:action="@{/orders/new}" method="post">
+            <input type="hidden" name=itemId th:value="${item.id}">
             <div class="quantity">
               <label for="count">수량</label>
-              <input type="number" id="count" th:value="orderQuantity" placeholder="1">
+              <input type="number" id="count" min="1" placeholder="1" th:field="${orderFormDto.orderQuantity}">
             </div>
             <hr/>
-            <div class="total-price">
+            <!--<div class="total-price">
               총 상품금액 : <span>1000</span>원
-            </div>
+            </div>-->
             <div class="order-click">
               <a href="" class="add-cart">
                 <img src="/img/icon/add-to-cart-black.png">
               </a>
               <button type="submit" class="btn btn-outline-secondary">Buy Now</button>
             </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   </div> <!-- /container -->
@@ -57,6 +58,10 @@
 
 <!-- ======= Footer ======= -->
 <div th:replace="fragments/footer :: footer"></div>
+
+<script>
+
+</script>
 </body>
 
 </html>

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -25,23 +25,22 @@
       <div class="item-info col-lg-5">
         <h2 th:text="${item.name}">상품 이름</h2>
         <hr/>
-        <h3>
-          <sapn th:text="${item.price}">1000</sapn>
-          원
-        </h3>
+        <table>
+          <th>price</th>
+          <td>
+            <span th:text="${item.price}">상품 가격</span>원
+          </td>
+        </table>
 
         <form action="" method="post">
           <div class="order-info">
             <div class="quantity">
-              <h4>Quantity</h4>
-              <span class="plus">+</span>
-              <input type="number" readonly value="1">
-              <span class="minus">-</span>
+              <label for="count">수량</label>
+              <input type="number" id="count" th:value="orderQuantity" placeholder="1">
             </div>
             <hr/>
             <div class="total-price">
-              <h4>total price : </h4>
-              <span class="price"> 1000원</span>
+              총 상품금액 : <span>1000</span>원
             </div>
             <div class="order-click">
               <a href="" class="add-cart">

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -19,10 +19,10 @@
     </div>
 
     <div class="row gy-4">
-      <div class="item_img col-lg-8">
-        <img th:src="|/files/${item.mainImage.getStoreFileName()}|" class="main_img" width="400" height="400">
+      <div class="item-img col-lg-7">
+        <img th:src="|/files/${item.mainImage.getStoreFileName()}|" class="main-img">
       </div>
-      <div class="item_info col-lg-4">
+      <div class="item-info col-lg-5">
         <h2 th:text="${item.name}">상품 이름</h2>
         <hr/>
         <h3>
@@ -31,7 +31,7 @@
         </h3>
 
         <form action="" method="post">
-          <div class="order_info">
+          <div class="order-info">
             <div class="quantity">
               <h4>Quantity</h4>
               <span class="plus">+</span>
@@ -39,15 +39,15 @@
               <span class="minus">-</span>
             </div>
             <hr/>
-            <div class="total_price">
+            <div class="total-price">
               <h4>total price : </h4>
               <span class="price"> 1000원</span>
             </div>
-            <div class="order_click d-flex justify-content-end">
-              <a href="" class="add_cart">
+            <div class="order-click">
+              <a href="" class="add-cart">
                 <img src="/img/icon/add-to-cart-black.png">
               </a>
-              <button type="submit">Buy Now</button>
+              <button type="submit" class="btn btn-outline-secondary">Buy Now</button>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 상품 상세 폼에서 단건 주문 처리

## 📋 작업사항
- 상품 상세 폼 css와 구성 변경
- 상품 상세 폼에서 주문 컨트롤러로 값을 넘겨주기 위해 상품 상세 컨트롤러에서 빈 `OrderFormDto` 객체를 모델에 담아 넘겨줌
- 상품 상세 폼에서 `상품 ID`와 `수량` 값을 주문 컨트롤러로 전달하도록 함
- 주문 컨트롤러에서 DTO로 값을 받을 때 `itemName`과 `itemPrice`는 DB에서 조회해온 값으로 주입해주도록 함
