### PR TITLE
refactor: 질문 검색 기준을 1개로 통합

### DIFF
--- a/src/main/java/shop/tryit/domain/question/QuestionSearchCondition.java
+++ b/src/main/java/shop/tryit/domain/question/QuestionSearchCondition.java
@@ -8,13 +8,11 @@ import lombok.ToString;
 @ToString
 public class QuestionSearchCondition {
 
-    private String title;
-    private String email;
+    private String condition;
 
     @Builder
-    private QuestionSearchCondition(String title, String email) {
-        this.title = title;
-        this.email = email;
+    private QuestionSearchCondition(String condition, String email) {
+        this.condition = condition;
     }
 
 }

--- a/src/main/java/shop/tryit/repository/question/QuestionCustomImpl.java
+++ b/src/main/java/shop/tryit/repository/question/QuestionCustomImpl.java
@@ -59,10 +59,7 @@ public class QuestionCustomImpl implements QuestionCustom {
         return queryFactory
                 .select(question.count())
                 .from(question)
-                .where(
-                        questionTitleEq(condition.getTitle()),
-                        memberEmailEq(condition.getEmail())
-                );
+                .where(containsCondition(condition.getCondition()));
     }
 
     private List<QuestionSearchDto> searchContent(QuestionSearchCondition condition, Pageable pageable) {
@@ -74,9 +71,7 @@ public class QuestionCustomImpl implements QuestionCustom {
                         question.createDate))
                 .from(question)
                 .innerJoin(question.member, member)
-                .where(
-                        questionTitleEq(condition.getTitle()),
-                        memberEmailEq(condition.getEmail())
+                .where(containsCondition(condition.getCondition())
                 )
                 .orderBy(question.createDate.desc())
                 .offset(pageable.getOffset())
@@ -93,12 +88,18 @@ public class QuestionCustomImpl implements QuestionCustom {
                 .fetch();
     }
 
-    private BooleanExpression questionTitleEq(String title) {
-        return StringUtils.hasText(title) ? question.title.contains(title):null;
+    private BooleanExpression containsCondition(String condition) {
+        String nullSafeCondition = StringUtils.hasText(condition) ? condition:"";
+        return questionTitleContains(nullSafeCondition).or(memberEmailContains(nullSafeCondition));
+
     }
 
-    private BooleanExpression memberEmailEq(String email) {
-        return StringUtils.hasText(email) ? question.member.email.contains(email):null;
+    private BooleanExpression questionTitleContains(String condition) {
+        return question.title.contains(condition);
+    }
+
+    private BooleanExpression memberEmailContains(String condition) {
+        return question.member.email.contains(condition);
     }
 
 }

--- a/src/main/resources/templates/questions/list.html
+++ b/src/main/resources/templates/questions/list.html
@@ -15,11 +15,8 @@
 
       <div>
         <form th:action method="get" th:object="${questionSearchCondition}">
-          <label th:for="name">제목으로 검색</label>
-          <input type="text" th:field="*{title}" class="form-control" placeholder="제목을 입력하세요.">
-
-          <label th:for="name">회원 아이디로 검색</label>
-          <input type="text" th:field="*{email}" class="form-control" placeholder="아이디를 입력하세요">
+          <label th:for="name"> 검색</label>
+          <input type="text" th:field="*{condition}" class="form-control">
           <button type="submit" class="btn btn-primary">검색</button>
         </form>
 
@@ -55,7 +52,7 @@
 
           <li th:each="i : ${pages}">
             <a class="page-link" href="#"
-               th:href="@{/questions(page=${i - 1}, title=${questionSearchCondition.title}, email=${questionSearchCondition.email})}"
+               th:href="@{/questions(page=${i - 1}, condition=${questionSearchCondition.condition})}"
                th:text="${i}"></a>
           </li>
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 질문 검색 기준을 1개로 통합

## 📋 작업사항
- 질문 검색 기준인 `제목`, `이메일` 을 1개로 통합 

