### PR TITLE
feat: 장바구니 생성 서비스 로직 개발

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/repository/CartRepository.java
+++ b/src/main/java/shop/tryit/domain/cart/repository/CartRepository.java
@@ -1,9 +1,12 @@
 package shop.tryit.domain.cart.repository;
 
 import shop.tryit.domain.cart.entity.Cart;
+import shop.tryit.domain.member.Member;
 
 public interface CartRepository {
 
     Long save(Cart cart);
+
+    Cart findByMember(Member member);
 
 }

--- a/src/main/java/shop/tryit/domain/cart/service/CartService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartService.java
@@ -1,10 +1,14 @@
 package shop.tryit.domain.cart.service;
 
+import static java.util.Objects.isNull;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.repository.CartRepository;
+import shop.tryit.domain.member.Member;
+import shop.tryit.domain.member.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -12,12 +16,27 @@ import shop.tryit.domain.cart.repository.CartRepository;
 public class CartService {
 
     private final CartRepository cartRepository;
+    private final MemberRepository memberRepository;
 
     /**
-     * 장바구니 등록
+     * 장바구니 생성
      */
-    public Long register(Cart cart) {
-        return cartRepository.save(cart);
+    @Transactional
+    public Long createCart(String email) {
+        // 현재 로그인한 회원 엔티티 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalStateException("해당 회원을 찾을 수 없습니다."));
+
+        // 회원의 장바구니 엔티티 조회
+        Cart cart = cartRepository.findByMember(member);
+
+        // 회원에게 장바구니가 없을 경우, 장바구니 생성
+        if (isNull(cart)) {
+            cart = Cart.from(member);
+            cartRepository.save(cart);
+        }
+
+        return cart.getId();
     }
 
 }

--- a/src/main/java/shop/tryit/repository/cart/CartJpaRepository.java
+++ b/src/main/java/shop/tryit/repository/cart/CartJpaRepository.java
@@ -2,7 +2,9 @@ package shop.tryit.repository.cart;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.tryit.domain.cart.entity.Cart;
+import shop.tryit.domain.member.Member;
 
 public interface CartJpaRepository extends JpaRepository<Cart, Long> {
+    Cart findByMember(Member member);
 
 }

--- a/src/main/java/shop/tryit/repository/cart/CartRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/cart/CartRepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.repository.CartRepository;
+import shop.tryit.domain.member.Member;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,6 +15,11 @@ public class CartRepositoryImpl implements CartRepository {
     @Override
     public Long save(Cart cart) {
         return cartJpaRepository.save(cart).getId();
+    }
+
+    @Override
+    public Cart findByMember(Member member) {
+        return cartJpaRepository.findByMember(member);
     }
 
 }

--- a/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
@@ -1,37 +1,47 @@
 package shop.tryit.domain.cart;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.service.CartService;
 import shop.tryit.domain.member.Member;
+import shop.tryit.domain.member.MemberRepository;
 import shop.tryit.repository.cart.CartJpaRepository;
 
 @Transactional
 @SpringBootTest
-class CartServiceTests {
+public class CartServiceTests {
+
+    @Autowired
+    CartService sut;
 
     @Autowired
     CartJpaRepository cartJpaRepository;
 
     @Autowired
-    CartService sut;
+    MemberRepository memberRepository;
+
+    private Member saveMember() {
+        Member member = Member.builder()
+                .email("test@test.com")
+                .build();
+        memberRepository.save(member);
+        return member;
+    }
 
     @Test
-    void 장바구니_등록() {
+    void 장바구니_생성() {
         // given
-        Member member = Member.builder().build();
-        Cart cart = Cart.from(member);
+        Member member = saveMember();
 
         // when
-        Long savedId = sut.register(cart);
+        Long cartId = sut.createCart(member.getEmail());
 
         // then
-        assertTrue(cartJpaRepository.findById(savedId).isPresent());
+        assertNotNull(cartJpaRepository.findById(cartId));
     }
 
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 회원 별로 하나의 장바구니를 생성하는 기능 개발

## 📋 작업사항
- 장바구니 레포지토리에 `findByMember()` 추가
- 장바구니 생성 비즈니스 로직 구현
  - 해당 회원에게 장바구니가 없을 경우에만 장바구니를 생성하도록 구현
- 장바구니 생성 비즈니스 로직 테스트 코드