### PR TITLE
feat: 장바구니 상품 추가 서비스 로직 개발

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -42,4 +42,12 @@ public class CartItem {
         this.count = count;
     }
 
+    /**
+     * 비즈니스 로직
+     **/
+    // 장바구니에 이미 상품이 있을 경우 개수 증가를 위한 로직
+    public void addCount(int count) {
+        this.count += count;
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
@@ -1,9 +1,13 @@
 package shop.tryit.domain.cart.repository;
 
+import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
+import shop.tryit.domain.item.Item;
 
 public interface CartItemRepository {
 
     Long save(CartItem cartItem);
+
+    CartItem findByCartAndItem(Cart cart, Item item);
 
 }

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -1,10 +1,14 @@
 package shop.tryit.domain.cart.service;
 
+import static java.util.Objects.nonNull;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.cart.repository.CartItemRepository;
+import shop.tryit.domain.item.Item;
+import shop.tryit.domain.item.ItemRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -12,12 +16,35 @@ import shop.tryit.domain.cart.repository.CartItemRepository;
 public class CartItemService {
 
     private final CartItemRepository cartItemRepository;
+    private final ItemRepository itemRepository;
 
     /**
-     * 장바구니 상품 등록
+     * 장바구니에 상품 추가
      */
-    public Long register(CartItem cartItem) {
-        return cartItemRepository.save(cartItem);
+    @Transactional
+    public Long addCartItem(CartItem cartItem) {
+        // 장바구니에 담을 상품 엔티티 조회
+        Item item = itemRepository.findById(cartItem.getItem().getId())
+                .orElseThrow(() -> new IllegalStateException("해당 상품을 찾을 수 없습니다."));
+
+        // 장바구니에 해당 상품이 있는지 확인
+        CartItem savedCartItem = cartItemRepository.findByCartAndItem(cartItem.getCart(), item);
+
+        // 상품이 이미 있을 경우, 개수 증가
+        if (nonNull(savedCartItem)) {
+            savedCartItem.addCount(cartItem.getCount());
+            return savedCartItem.getId();
+        }
+
+        // 상품이 없을 경우, 장바구니에 상품 추가
+        savedCartItem = CartItem.builder()
+                .cart(cartItem.getCart())
+                .item(cartItem.getItem())
+                .count(cartItem.getCount())
+                .build();
+        cartItemRepository.save(savedCartItem);
+
+        return savedCartItem.getId();
     }
 
 }

--- a/src/main/java/shop/tryit/repository/cart/CartItemJpaRepository.java
+++ b/src/main/java/shop/tryit/repository/cart/CartItemJpaRepository.java
@@ -1,8 +1,12 @@
 package shop.tryit.repository.cart;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
+import shop.tryit.domain.item.Item;
 
 public interface CartItemJpaRepository extends JpaRepository<CartItem, Long> {
+
+    CartItem findByCartAndItem(Cart cart, Item item);
 
 }

--- a/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
@@ -2,8 +2,10 @@ package shop.tryit.repository.cart;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.cart.repository.CartItemRepository;
+import shop.tryit.domain.item.Item;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,6 +16,11 @@ public class CartItemRepositoryImpl implements CartItemRepository {
     @Override
     public Long save(CartItem cartItem) {
         return cartItemJpaRepository.save(cartItem).getId();
+    }
+
+    @Override
+    public CartItem findByCartAndItem(Cart cart, Item item) {
+        return cartItemJpaRepository.findByCartAndItem(cart, item);
     }
 
 }

--- a/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
@@ -1,6 +1,7 @@
 package shop.tryit.domain.cart;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,28 +9,58 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.cart.service.CartItemService;
+import shop.tryit.domain.item.Item;
+import shop.tryit.domain.item.ItemRepository;
 import shop.tryit.repository.cart.CartItemJpaRepository;
 
 @Transactional
 @SpringBootTest
-class CartItemServiceTests {
-
+public class CartItemServiceTests {
     @Autowired
     CartItemJpaRepository cartItemJpaRepository;
 
     @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
     CartItemService sut;
 
+    private Item saveItem() {
+        Item item = Item.builder().build();
+        itemRepository.save(item);
+        return item;
+    }
+
     @Test
-    void 장바구니_상품_등록() {
+    void 장바구니에_상품이_없다면_상품_추가() {
         // given
-        CartItem cartItem = CartItem.builder().build();
+        Item item = saveItem();
+
+        CartItem cartItem = CartItem.builder().item(item).build();
 
         // when
-        Long savedId = sut.register(cartItem);
+        Long savedCartItemId = sut.addCartItem(cartItem); // 장바구니 상품 아이디
 
         // then
-        assertTrue(cartItemJpaRepository.findById(savedId).isPresent());
+        assertNotNull(cartItemJpaRepository.findById(savedCartItemId));
+    }
+
+    @Test
+    void 장바구니에_상품이_있다면_개수_증가() {
+        // given
+        Item item = saveItem();
+
+        CartItem cartItem = CartItem.builder()
+                .item(item)
+                .count(2)
+                .build();
+        cartItemJpaRepository.save(cartItem);
+
+        // when
+        Long savedCartItemId = sut.addCartItem(cartItem);
+
+        // then
+        assertThat(cartItemJpaRepository.findById(savedCartItemId).get().getCount()).isEqualTo(4);
     }
 
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니에 상품을 추가하는 기능 개발

## 📋 작업사항
- 장바구니 상품 레포지토리에 `findByCartAndItem()` 추가
- 장바구니 상품 엔티티에 `addCount()` 추가
- 장바구니 상품 추가 비즈니스 로직 수정
   - 장바구니에 같은 상품을 담을 경우 개수가 증가하도록 구현
   - 장바구니에 새로운 상품을 담을 경우 장바구니 상품을 추가하도록 구현 
- 장바구니 상품 추가 비즈니스 로직 테스트 코드
