### PR TITLE
feat: 장바구니 상품 수정 기능 개발

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -45,7 +45,7 @@ public class CartItem {
     /**
      * 비즈니스 로직
      **/
-    // 장바구니에 이미 상품이 있을 경우 개수 증가를 위한 로직
+    // 장바구니에 이미 상품이 있을 경우 수량 증가를 위한 로직
     public void addCount(int count) {
         this.count += count;
     }

--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -50,4 +50,9 @@ public class CartItem {
         this.count += count;
     }
 
+    // 장바구니 상품의 수량 변경을 위한 로직
+    public void updateCount(int count) {
+        this.count = count;
+    }
+
 }

--- a/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
@@ -1,6 +1,7 @@
 package shop.tryit.domain.cart.repository;
 
 import java.util.List;
+import java.util.Optional;
 import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.item.Item;
@@ -8,6 +9,8 @@ import shop.tryit.domain.item.Item;
 public interface CartItemRepository {
 
     Long save(CartItem cartItem);
+
+    Optional<CartItem> findById(Long cartItemId);
 
     CartItem findByCartAndItem(Cart cart, Item item);
 

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -56,4 +56,17 @@ public class CartItemService {
         return cartItemRepository.findByCart(cart);
     }
 
+    /**
+     * 장바구니에 담긴 상품 수량 변경
+     */
+    @Transactional
+    public void updateCartItemCount(Long cartItemId, int count) {
+        // 변경할 장바구니 상품 엔티티 조회
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new IllegalStateException("해당 장바구니 상품을 찾을 수 없습니다."));
+
+        // 장바구니 상품의 수량 변경
+        cartItem.updateCount(count);
+    }
+
 }

--- a/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
@@ -1,6 +1,7 @@
 package shop.tryit.repository.cart;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import shop.tryit.domain.cart.entity.Cart;
@@ -17,6 +18,11 @@ public class CartItemRepositoryImpl implements CartItemRepository {
     @Override
     public Long save(CartItem cartItem) {
         return cartItemJpaRepository.save(cartItem).getId();
+    }
+
+    @Override
+    public Optional<CartItem> findById(Long cartItemId) {
+        return cartItemJpaRepository.findById(cartItemId);
     }
 
     @Override

--- a/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
@@ -74,10 +74,7 @@ class CartItemServiceTests {
         // given
         Item item = saveItem();
 
-        CartItem cartItem = CartItem.builder()
-                .item(item)
-                .count(2)
-                .build();
+        CartItem cartItem = CartItem.builder().item(item).count(2).build();
         cartItemJpaRepository.save(cartItem);
 
         // when
@@ -106,6 +103,21 @@ class CartItemServiceTests {
 
         // then
         assertThat(cartItemList).hasSize(2);
+    }
+
+    @Test
+    void 장바구니에_담긴_상품_수량_변경() {
+        // given
+        Item item = saveItem();
+
+        CartItem cartItem = CartItem.builder().item(item).count(2).build();
+        cartItemJpaRepository.save(cartItem);
+
+        // when
+        sut.updateCartItemCount(cartItem.getId(), 5);
+
+        // then
+        assertThat(cartItem.getCount()).isEqualTo(5);
     }
 
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 상품의 수량을 변경하는 기능을 개발

## 📋 작업사항
- 장바구니 상품 레포지토리에 `findById()` 추가
- 장바구니 상품 엔티티에 `updateCount()` 추가
- 장바구니에 담긴 상품의 수량을 변경하는 서비스 로직 구현 : `updateCartItemCount()`
- 장바구니에 담긴 상품의 수량을 변경하는 서비스 로직 테스트 코드
- 주석 메세지 수정
