### PR TITLE
feat: 장바구니 상품 삭제 기능 개발

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/shop/tryit/domain/cart/repository/CartItemRepository.java
@@ -16,4 +16,6 @@ public interface CartItemRepository {
 
     List<CartItem> findByCart(Cart cart);
 
+    void delete(CartItem cartItem);
+
 }

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -69,4 +69,16 @@ public class CartItemService {
         cartItem.updateCount(count);
     }
 
+    /**
+     * 장바구니에 담긴 상품 삭제
+     */
+    @Transactional
+    public void deleteCartItem(Long cartItemId) {
+        // 삭제할 장바구니 상품 엔티티 조회
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new IllegalStateException("해당 장바구니 상품을 찾을 수 없습니다."));
+
+        cartItemRepository.delete(cartItem);
+    }
+
 }

--- a/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/cart/CartItemRepositoryImpl.java
@@ -35,4 +35,9 @@ public class CartItemRepositoryImpl implements CartItemRepository {
         return cartItemJpaRepository.findByCart(cart);
     }
 
+    @Override
+    public void delete(CartItem cartItem) {
+        cartItemJpaRepository.delete(cartItem);
+    }
+
 }

--- a/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
@@ -120,4 +120,21 @@ class CartItemServiceTests {
         assertThat(cartItem.getCount()).isEqualTo(5);
     }
 
+    @Test
+    void 장바구니에_담긴_상품_삭제() {
+        // given
+        Item item = saveItem();
+
+        Cart cart = saveCart();
+
+        CartItem cartItem = CartItem.builder().item(item).cart(cart).build();
+        cartItemJpaRepository.save(cartItem);
+
+        // when
+        sut.deleteCartItem(cartItem.getId());
+
+        // then
+        assertThat(cartItemJpaRepository.findByCart(cart)).isEmpty();
+    }
+
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니에 담긴 상품을 삭제하는 기능 개발

## 📋 작업사항
- 장바구니 상품 레포지토리에 `delete()` 추가
- 장바구니에 담긴 상품을 삭제하는 비즈니스 로직 구현 : `deleteCartItem`
- 장바구니에 담긴 상품을 삭제하는 비즈니스 로직 테스트 코드

## 💬 참고사항
- 장바구니 상품의 주문이 일어나 장바구니에서 삭제되는 경우는 추후에 주문과 맞춰서 진행하도록 한다.