### PR TITLE
feat: 상품 상세에서 단건 주문 시 결제 컨트롤러로 정보 전달

### DIFF
--- a/src/main/java/shop/tryit/web/item/ItemController.java
+++ b/src/main/java/shop/tryit/web/item/ItemController.java
@@ -22,7 +22,6 @@ import shop.tryit.domain.item.Item;
 import shop.tryit.domain.item.ItemSearchCondition;
 import shop.tryit.domain.item.ItemSearchDto;
 import shop.tryit.domain.item.ItemService;
-import shop.tryit.web.order.OrderFormDto;
 
 @Slf4j
 @Controller
@@ -138,7 +137,6 @@ public class ItemController {
 
         ItemDto itemDto = ItemAdapter.toDto(item, imageService.getMainImage(id), imageService.getDetailImage(id));
         model.addAttribute("item", itemDto);
-        model.addAttribute("orderFormDto", OrderFormDto.builder().build());
 
         return "/items/detail";
     }

--- a/src/main/java/shop/tryit/web/payment/PaymentController.java
+++ b/src/main/java/shop/tryit/web/payment/PaymentController.java
@@ -13,13 +13,16 @@ import shop.tryit.domain.payment.PaymentService;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/payment")
-public class PayController {
+public class PaymentController {
 
     private final PaymentService paymentService;
 
     @GetMapping
-    public String newKakapay(@ModelAttribute PaymentFormDto paymentFormDto) {
-        log.info("--------------결제하기----------------");
+    public String newPaymentForm(@ModelAttribute PaymentFormDto paymentFormDto) {
+        log.info("======== 결제 폼 컨트롤러 시작 ========");
+        log.info("결제할 상품 아이디 = {}", paymentFormDto.getItemId());
+        log.info("결제할 상품 수량 = {}", paymentFormDto.getQuantity());
+
         return "/payment/payment-form";
     }
 

--- a/src/main/java/shop/tryit/web/payment/PaymentController.java
+++ b/src/main/java/shop/tryit/web/payment/PaymentController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import shop.tryit.domain.payment.PaymentService;
@@ -17,7 +18,7 @@ public class PayController {
     private final PaymentService paymentService;
 
     @GetMapping
-    public String newKakapay() {
+    public String newKakapay(@ModelAttribute PaymentFormDto paymentFormDto) {
         log.info("--------------결제하기----------------");
         return "/payment/payment-form";
     }

--- a/src/main/java/shop/tryit/web/payment/PaymentFormDto.java
+++ b/src/main/java/shop/tryit/web/payment/PaymentFormDto.java
@@ -1,0 +1,14 @@
+package shop.tryit.web.payment;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PaymentFormDto {
+
+    private Long itemId;
+
+    private int quantity;
+
+}

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -33,11 +33,11 @@
         </table>
 
         <div class="order-info">
-          <form th:action="@{/orders/new}" method="post">
-            <input type="hidden" name=itemId th:value="${item.id}">
+          <form th:action="@{/payment}" method="get">
+            <input type="hidden" id="itemId" name=itemId th:value="${item.id}">
             <div class="quantity">
-              <label for="count">수량</label>
-              <input type="number" id="count" min="1" placeholder="1" th:field="${orderFormDto.orderQuantity}">
+              <label for="quantity">수량</label>
+              <input type="number" id="quantity" min="1" value="1" name="quantity">
             </div>
             <hr/>
             <!--<div class="total-price">


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 결제 기능 추가로 인해 상품 상세에서 단건 주문 시 결제 컨트롤러로 정보 전달하도록 함.

## 📋 작업사항
- 상품 상세 폼에서 주문하기 버튼을 눌렀을 때 주문 컨트롤러가 아닌 결제 컨트롤러로 전달되도록 변경
- 결제 컨트롤러에서 정보를 받기 위한 결제 폼 DTO 생성 : `PaymentFormDto`
- 정보가 잘 넘어가는지 확인을 위해 결제 폼 생성 컨트롤러에 `@ModelAttribute` 추가
- style 수정
   - 클래스명 : `PayController` -> `PaymentController`
   - 메소드명 : `newKakapay` -> `newPaymentForm` (새로운 결제폼 생성의 의미)

## 💬 추가사항
- @Kimjunghyunn 
   - 결제할 상품의 정보 전달 여부 확인만 해놓은 상태라서 전달받은 정보를 Model에 담아 View로 전달하는 로직을 추가해주면 될 것 같아요.😊