### PR TITLE
feat: 장바구니 웹 계층 개발 (상품 담기)

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -33,26 +33,26 @@ public class CartItem {
     @JoinColumn(name = "cart_id")
     private Cart cart;
 
-    private int count;
+    private int quantity;
 
     @Builder
-    private CartItem(Item item, Cart cart, int count) {
+    private CartItem(Item item, Cart cart, int quantity) {
         this.item = item;
         this.cart = cart;
-        this.count = count;
+        this.quantity = quantity;
     }
 
     /**
      * 비즈니스 로직
      **/
     // 장바구니에 이미 상품이 있을 경우 수량 증가를 위한 로직
-    public void addCount(int count) {
-        this.count += count;
+    public void addCount(int quantity) {
+        this.quantity += quantity;
     }
 
     // 장바구니 상품의 수량 변경을 위한 로직
-    public void updateCount(int count) {
-        this.count = count;
+    public void updateCount(int quantity) {
+        this.quantity = quantity;
     }
 
 }

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -34,7 +34,7 @@ public class CartItemService {
 
         // 상품이 이미 있을 경우, 개수 증가
         if (nonNull(savedCartItem)) {
-            savedCartItem.addCount(cartItem.getCount());
+            savedCartItem.addCount(cartItem.getQuantity());
             return savedCartItem.getId();
         }
 
@@ -42,7 +42,7 @@ public class CartItemService {
         savedCartItem = CartItem.builder()
                 .cart(cartItem.getCart())
                 .item(cartItem.getItem())
-                .count(cartItem.getCount())
+                .quantity(cartItem.getQuantity())
                 .build();
         cartItemRepository.save(savedCartItem);
 

--- a/src/main/java/shop/tryit/domain/cart/service/CartService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartService.java
@@ -19,10 +19,10 @@ public class CartService {
     private final MemberRepository memberRepository;
 
     /**
-     * 장바구니 생성
+     * 장바구니 조회
      */
     @Transactional
-    public Cart createCart(String email) {
+    public Cart findCart(String email) {
         // 현재 로그인한 회원 엔티티 조회
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalStateException("해당 회원을 찾을 수 없습니다."));

--- a/src/main/java/shop/tryit/domain/cart/service/CartService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartService.java
@@ -22,7 +22,7 @@ public class CartService {
      * 장바구니 생성
      */
     @Transactional
-    public Long createCart(String email) {
+    public Cart createCart(String email) {
         // 현재 로그인한 회원 엔티티 조회
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalStateException("해당 회원을 찾을 수 없습니다."));
@@ -36,7 +36,7 @@ public class CartService {
             cartRepository.save(cart);
         }
 
-        return cart.getId();
+        return cart;
     }
 
 }

--- a/src/main/java/shop/tryit/web/cart/controller/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/controller/CartController.java
@@ -1,0 +1,73 @@
+package shop.tryit.web.cart.controller;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import shop.tryit.domain.cart.entity.Cart;
+import shop.tryit.domain.cart.entity.CartItem;
+import shop.tryit.domain.cart.service.CartItemService;
+import shop.tryit.domain.cart.service.CartService;
+import shop.tryit.domain.item.ImageService;
+import shop.tryit.domain.item.Item;
+import shop.tryit.domain.item.ItemService;
+import shop.tryit.web.cart.dto.CartItemAdapter;
+import shop.tryit.web.cart.dto.CartItemDto;
+
+@Slf4j
+@Controller
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartItemService cartItemService;
+    private final CartService cartService;
+    private final ItemService itemService;
+    private final ImageService imageService;
+
+    /**
+     * 장바구니에 상품 담기
+     */
+    @PostMapping
+    public @ResponseBody ResponseEntity addCartItem(@Valid @ModelAttribute CartItemDto cartItemDto,
+                                                    BindingResult bindingResult,
+                                                    @AuthenticationPrincipal User user) {
+        log.info("장바구니에 담을 상품의 id = {}", cartItemDto.getItemId());
+        log.info("장바구니에 담을 상품의 수량 = {}", cartItemDto.getQuantity());
+
+        Cart cart = cartService.findCart(user.getUsername());
+        Item item = itemService.findOne(cartItemDto.getItemId());
+
+        // 수량 검증
+        if (item.getStockQuantity() < cartItemDto.getQuantity()) {
+            bindingResult.rejectValue("quantity", "StockError", String.format("현재 남은 수량은 %d개 입니다.%n %d개 이하로 담아주세요.", item.getStockQuantity(), item.getStockQuantity()));
+        }
+
+        // 검증 실패시 400
+        if (bindingResult.hasErrors()) {
+            StringBuilder sb = new StringBuilder();
+
+            for (FieldError error : bindingResult.getFieldErrors())
+                sb.append(error.getDefaultMessage());
+
+            return new ResponseEntity<String>(sb.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        // 검증 성공시 장바구니에 상품 담기
+        CartItem cartItem = CartItemAdapter.toEntity(cartItemDto, item, cart);
+        Long cartItemId = cartItemService.addCartItem(cartItem);
+
+        return new ResponseEntity<Long>(cartItemId, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
+++ b/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
@@ -1,0 +1,21 @@
+package shop.tryit.web.cart.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.NoArgsConstructor;
+import shop.tryit.domain.cart.entity.Cart;
+import shop.tryit.domain.cart.entity.CartItem;
+import shop.tryit.domain.item.Item;
+
+@NoArgsConstructor(access = PRIVATE)
+public class CartItemAdapter {
+
+    public static CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
+        return CartItem.builder()
+                .cart(cart)
+                .item(item)
+                .quantity(cartItemDto.getQuantity())
+                .build();
+    }
+
+}

--- a/src/main/java/shop/tryit/web/cart/dto/CartItemDto.java
+++ b/src/main/java/shop/tryit/web/cart/dto/CartItemDto.java
@@ -1,0 +1,26 @@
+package shop.tryit.web.cart.dto;
+
+import javax.validation.constraints.Min;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/* 장바구니에 담을 상품의 id와 수량을 받음 */
+@Data
+@NoArgsConstructor
+public class CartItemDto {
+
+    private Long itemId;
+
+    @Min(value = 1, message = "최소 1개 이상 담아주세요.")
+    private int quantity;
+
+    private CartItemDto(Long itemId, int quantity) {
+        this.itemId = itemId;
+        this.quantity = quantity;
+    }
+
+    public static CartItemDto of(Long itemId, int quantity) {
+        return new CartItemDto(itemId, quantity);
+    }
+
+}

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -44,9 +44,7 @@
               총 상품금액 : <span>1000</span>원
             </div>-->
             <div class="order-click">
-              <a href="" class="add-cart">
-                <img src="/img/icon/add-to-cart-black.png">
-              </a>
+              <button type="button" id="addCartItem" class="btn btn-secondary" value="장바구니 담기">Add Cart</button>
               <button type="submit" class="btn btn-outline-secondary">Buy Now</button>
             </div>
           </form>
@@ -59,7 +57,26 @@
 <!-- ======= Footer ======= -->
 <div th:replace="fragments/footer :: footer"></div>
 
-<script>
+<script th:inline="javascript">
+  $('#addCartItem').click(function() {
+    var url = "/cart";
+    var data = {
+      itemId : $('#itemId').val(),
+      quantity : $('#quantity').val()
+    };
+
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: data,
+      success: function(result) {
+        alert("장바구니에 상품을 추가했습니다.🛒");
+      },
+      error: function(jqXHR) {
+        alert(jqXHR.responseText);
+      }
+    })
+  })
 
 </script>
 </body>

--- a/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
@@ -74,14 +74,14 @@ class CartItemServiceTests {
         // given
         Item item = saveItem();
 
-        CartItem cartItem = CartItem.builder().item(item).count(2).build();
+        CartItem cartItem = CartItem.builder().item(item).quantity(2).build();
         cartItemJpaRepository.save(cartItem);
 
         // when
         Long savedCartItemId = sut.addCartItem(cartItem);
 
         // then
-        assertThat(cartItemJpaRepository.findById(savedCartItemId).get().getCount()).isEqualTo(4);
+        assertThat(cartItemJpaRepository.findById(savedCartItemId).get().getQuantity()).isEqualTo(4);
     }
 
     @Test
@@ -110,14 +110,14 @@ class CartItemServiceTests {
         // given
         Item item = saveItem();
 
-        CartItem cartItem = CartItem.builder().item(item).count(2).build();
+        CartItem cartItem = CartItem.builder().item(item).quantity(2).build();
         cartItemJpaRepository.save(cartItem);
 
         // when
         sut.updateCartItemCount(cartItem.getId(), 5);
 
         // then
-        assertThat(cartItem.getCount()).isEqualTo(5);
+        assertThat(cartItem.getQuantity()).isEqualTo(5);
     }
 
     @Test

--- a/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.service.CartService;
 import shop.tryit.domain.member.Member;
 import shop.tryit.domain.member.MemberRepository;
@@ -13,7 +14,7 @@ import shop.tryit.repository.cart.CartJpaRepository;
 
 @Transactional
 @SpringBootTest
-public class CartServiceTests {
+class CartServiceTests {
 
     @Autowired
     CartService sut;
@@ -38,10 +39,10 @@ public class CartServiceTests {
         Member member = saveMember();
 
         // when
-        Long cartId = sut.createCart(member.getEmail());
+        Cart cart = sut.createCart(member.getEmail());
 
         // then
-        assertNotNull(cartJpaRepository.findById(cartId));
+        assertNotNull(cartJpaRepository.findById(cart.getId()));
     }
 
 }

--- a/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartServiceTests.java
@@ -34,12 +34,12 @@ class CartServiceTests {
     }
 
     @Test
-    void 장바구니_생성() {
+    void 장바구니_조회() {
         // given
         Member member = saveMember();
 
         // when
-        Cart cart = sut.createCart(member.getEmail());
+        Cart cart = sut.findCart(member.getEmail());
 
         // then
         assertNotNull(cartJpaRepository.findById(cart.getId()));


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 웹 계층 개발 (상품 담기)

## 📋 작업사항
- 장바구니 상품 Dto 생성
- 장바구니 상품 Dto ➡ Entity 변환 어댑터 생성
- 상품 상세 폼에서 장바구니 담기 버튼을 클릭 시 데이터를 전달하는 자바스크립트 코드 추가

- 리팩토링
   - 장바구니 생성 서비스 로직 반환 타입 변경 및 테스트 코드 수정  
   - 장바구니 상품 Entity 수량 필드명을 `count` ➡ `quantity`로 변경
   - 장바구니 서비스 로직 메소드명을 `createCart` ➡ `findCart`로 변경
