### PR TITLE
feat: 장바구니 웹 계층 개발 (조회)

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -42,6 +42,18 @@ public class CartItem {
         this.quantity = quantity;
     }
 
+    public Long getItemId() {
+        return item.getId();
+    }
+
+    public String getItemName() {
+        return item.getName();
+    }
+
+    public int getItemPrice() {
+        return item.getPrice();
+    }
+
     /**
      * 비즈니스 로직
      **/

--- a/src/main/java/shop/tryit/web/cart/controller/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/controller/CartController.java
@@ -88,7 +88,7 @@ public class CartController {
         List<CartItem> cartItems = cartItemService.findCartItemList(cart);
 
         List<Image> mainImages = cartItems.stream()
-                .map(cartItem -> cartItem.getItem().getId()) // CartItem -> Long
+                .map(cartItem -> cartItem.getItemId()) // CartItem -> Long
                 .map(imageService::getMainImage)// Long -> Image
                 .collect(toList());
 

--- a/src/main/java/shop/tryit/web/cart/controller/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/controller/CartController.java
@@ -1,5 +1,9 @@
 package shop.tryit.web.cart.controller;
 
+import static java.util.stream.Collectors.toList;
+
+import java.security.Principal;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,8 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +24,13 @@ import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.cart.service.CartItemService;
 import shop.tryit.domain.cart.service.CartService;
+import shop.tryit.domain.item.Image;
 import shop.tryit.domain.item.ImageService;
 import shop.tryit.domain.item.Item;
 import shop.tryit.domain.item.ItemService;
 import shop.tryit.web.cart.dto.CartItemAdapter;
 import shop.tryit.web.cart.dto.CartItemDto;
+import shop.tryit.web.cart.dto.CartListDto;
 
 @Slf4j
 @Controller
@@ -68,6 +76,27 @@ public class CartController {
         Long cartItemId = cartItemService.addCartItem(cartItem);
 
         return new ResponseEntity<Long>(cartItemId, HttpStatus.OK);
+    }
+
+    /**
+     * 장바구니에 담긴 상품 조회
+     */
+    @GetMapping
+    public String list(Model model, Principal principal) {
+        Cart cart = cartService.findCart(principal.getName());
+
+        List<CartItem> cartItems = cartItemService.findCartItemList(cart);
+
+        List<Image> mainImages = cartItems.stream()
+                .map(cartItem -> cartItem.getItem().getId()) // CartItem -> Long
+                .map(imageService::getMainImage)// Long -> Image
+                .collect(toList());
+
+        List<CartListDto> cartListDtos = CartItemAdapter.toDto(cartItems, mainImages);
+
+        model.addAttribute("cartListDtos", cartListDtos);
+
+        return "/cart/list";
     }
 
 }

--- a/src/main/java/shop/tryit/web/cart/controller/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/controller/CartController.java
@@ -94,6 +94,7 @@ public class CartController {
 
         List<CartListDto> cartListDtos = CartItemAdapter.toDto(cartItems, mainImages);
 
+        // TODO: proxy 이슈 해결
         model.addAttribute("cartListDtos", cartListDtos);
 
         return "/cart/list";

--- a/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
+++ b/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
@@ -23,9 +23,9 @@ public class CartItemAdapter {
 
     public static CartListDto toDto(CartItem cartItem, Image mainImage) {
         return CartListDto.builder()
-                .itemId(cartItem.getItem().getId())
-                .itemName(cartItem.getItem().getName())
-                .itemPrice(cartItem.getItem().getPrice())
+                .itemId(cartItem.getItemId())
+                .itemName(cartItem.getItemName())
+                .itemPrice(cartItem.getItemPrice())
                 .quantity(cartItem.getQuantity())
                 .mainImage(mainImage)
                 .build();

--- a/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
+++ b/src/main/java/shop/tryit/web/cart/dto/CartItemAdapter.java
@@ -2,9 +2,12 @@ package shop.tryit.web.cart.dto;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.NoArgsConstructor;
 import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
+import shop.tryit.domain.item.Image;
 import shop.tryit.domain.item.Item;
 
 @NoArgsConstructor(access = PRIVATE)
@@ -16,6 +19,26 @@ public class CartItemAdapter {
                 .item(item)
                 .quantity(cartItemDto.getQuantity())
                 .build();
+    }
+
+    public static CartListDto toDto(CartItem cartItem, Image mainImage) {
+        return CartListDto.builder()
+                .itemId(cartItem.getItem().getId())
+                .itemName(cartItem.getItem().getName())
+                .itemPrice(cartItem.getItem().getPrice())
+                .quantity(cartItem.getQuantity())
+                .mainImage(mainImage)
+                .build();
+    }
+
+    public static List<CartListDto> toDto(List<CartItem> cartItems, List<Image> mainImages) {
+        List<CartListDto> cartListDtos = new ArrayList<>();
+
+        for (int i = 0; i < cartItems.size(); i++) {
+            cartListDtos.add(toDto(cartItems.get(i), mainImages.get(i)));
+        }
+
+        return cartListDtos;
     }
 
 }

--- a/src/main/java/shop/tryit/web/cart/dto/CartListDto.java
+++ b/src/main/java/shop/tryit/web/cart/dto/CartListDto.java
@@ -1,0 +1,35 @@
+package shop.tryit.web.cart.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import shop.tryit.domain.item.Image;
+
+/* 장바구니 조회 시 전달 */
+@Data
+@NoArgsConstructor
+public class CartListDto {
+
+    private Long itemId; // 상품 ID
+
+    private String itemName; // 상품 이름
+
+    private int itemPrice; // 상품 금액
+
+    private int quantity; // 수량
+
+    private Image mainImage; // 상품 메인이미지
+
+    private int totalPrice; // 상품 금액 * 수량
+
+    @Builder
+    private CartListDto(Long itemId, String itemName, int itemPrice, int quantity, Image mainImage) {
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.itemPrice = itemPrice;
+        this.quantity = quantity;
+        this.mainImage = mainImage;
+        this.totalPrice = itemPrice * quantity;
+    }
+
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1315,6 +1315,30 @@ section {
 }
 
 /*--------------------------------------------------------------
+# Cart
+--------------------------------------------------------------*/
+.cart-list input {
+  width: 50px;
+  border: 1px solid #e5e5e5;
+  border-radius: 3px;
+  padding-left: 8px;
+  font-size: 15px;
+}
+
+.cart-list .table>:not(:first-child) {
+  border-top: 1px solid #e5e5e5;
+}
+
+.cart-list .table thead {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.cart-list .table tbody{
+  vertical-align: middle;
+  border-bottom: #f3f3f3;
+}
+
+/*--------------------------------------------------------------
 # Page
 --------------------------------------------------------------*/
 .pagination {

--- a/src/main/resources/templates/cart/list.html
+++ b/src/main/resources/templates/cart/list.html
@@ -1,0 +1,77 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="fragments/header :: header"></head>
+
+<body>
+<!-- ======= Header ======= -->
+<div th:replace="fragments/body-header :: body-header" id="header" class="fixed-top d-flex align-items-center"></div>
+
+<!-- ======= Item Section ======= -->
+<section class="item">
+  <div class="container">
+    <h3 class="text-center mb-5">
+      CART LIST
+    </h3>
+
+    <div class="cart-list">
+      <table class="table">
+        <colgroup>
+          <col width="5%">
+          <col width="10%">
+          <col width="25%">
+          <col width="15%">
+          <col width="15%">
+          <col width="15%">
+          <col width="15%">
+        </colgroup>
+        <thead>
+        <tr class="text-center">
+          <th>
+            <input type="checkbox">
+          </th>
+          <th>이미지</th>
+          <th class="text-left">상품정보</th>
+          <th>금액</th>
+          <th>수량</th>
+          <th>합계</th>
+          <th>삭제</th>
+        </tr>
+        </thead>
+
+        <tbody>
+        <tr class="text-center custom" th:each="cartListDto : ${cartListDtos}">
+          <td>
+            <input type="checkbox">
+          </td>
+          <td>
+            <a th:href="@{/items/{id}(id=${cartListDto.itemId})}">
+              <img th:src="|/files/${cartListDto.mainImage.getStoreFileName()}|" width="100" height="100"/>
+            </a>
+          </td>
+          <td th:text="${cartListDto.itemName}"></td>
+          <td>
+            <span th:text="${cartListDto.itemPrice}"></span>원
+          </td>
+          <td>
+            <label for="quantity"></label>
+            <input type="number" id="quantity" min="1" th:value="${cartListDto.quantity}">
+          </td>
+          <td>
+            <span th:text="${cartListDto.totalPrice}"></span>원
+          </td>
+          <td>
+            <button type="button" class="btn btn-light btn-sm">삭제</button>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </div> <!-- /container -->
+</section> <!-- End Item -->
+
+<!-- ======= Footer ======= -->
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+
+</html>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 웹 계층 개발 (조회)

## 📋 작업사항
- 장바구니 목록 Dto 생성 : `itemListDto`
- 장바구니 목록 Dto ➡ Entity 변환 어댑터 생성
- 장바구니에 담긴 상품 목록을 조회하는 컨트롤러 추가
- 장바구니 목록 뷰 생성 : `cart/list.html`
- css 코드 추가

- 리팩토링
   - 장바구니 상품 엔티티에 `getItemId()`, `getItemName()`, `getItemPrice()` 추가
   - 디미터 법칙을 준수하도록 컨트롤러, 어댑터 코드 리팩토링


## 💬 추가사항
- 현재 proxy 객체로 조회되어 발생되는 이슈 해결 필요