### PR TITLE
refactor: 장바구니 URI 변경

### DIFF
--- a/src/main/java/shop/tryit/web/cart/controller/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/controller/CartController.java
@@ -34,7 +34,7 @@ import shop.tryit.web.cart.dto.CartListDto;
 
 @Slf4j
 @Controller
-@RequestMapping("/cart")
+@RequestMapping("/carts")
 @RequiredArgsConstructor
 public class CartController {
 

--- a/src/main/resources/templates/fragments/body-header.html
+++ b/src/main/resources/templates/fragments/body-header.html
@@ -20,7 +20,7 @@
             <li><a class="nav-link scrollto" href="/members/edit"
                    sec:authorize="isAuthenticated()" th:href="@{/members/edit}">Modify</a></li>
             <li><a class="nav-link scrollto" href="/members/edit"
-                   sec:authorize="isAuthenticated()" th:href="@{/members/cart}">Cart</a></li>
+                   sec:authorize="isAuthenticated()" th:href="@{/carts}">Cart</a></li>
             <li><a class="nav-link scrollto" href="/members/edit"
                    sec:authorize="isAuthenticated()" th:href="@{/orders}">Order List</a></li>
           </ul>

--- a/src/main/resources/templates/items/detail.html
+++ b/src/main/resources/templates/items/detail.html
@@ -59,7 +59,7 @@
 
 <script th:inline="javascript">
   $('#addCartItem').click(function() {
-    var url = "/cart";
+    var url = "/carts";
     var data = {
       itemId : $('#itemId').val(),
       quantity : $('#quantity').val()
@@ -77,6 +77,7 @@
       }
     })
   })
+
 
 </script>
 </body>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 URI를 `/cart`에서 `/carts`로 변경

## 📋 작업사항
- 컨트롤러 매핑 경로 변경
- 상단 네비게이션바 장바구니 링크 변경