### PR TITLE
refactor: 장바구니 관련 리팩토링

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -58,12 +58,12 @@ public class CartItem {
      * 비즈니스 로직
      **/
     // 장바구니에 이미 상품이 있을 경우 수량 증가를 위한 로직
-    public void addCount(int quantity) {
+    public void addQuantity(int quantity) {
         this.quantity += quantity;
     }
 
     // 장바구니 상품의 수량 변경을 위한 로직
-    public void updateCount(int quantity) {
+    public void updateQuantity(int quantity) {
         this.quantity = quantity;
     }
 

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -19,6 +19,7 @@ import shop.tryit.domain.item.service.ItemService;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartFacade {
 
     private final CartItemService cartItemService;
@@ -29,7 +30,6 @@ public class CartFacade {
     /**
      * 장바구니 상품 추가
      */
-    @Transactional(readOnly = true)
     public Long addCartItem(CartItemDto cartItemDto, User user) {
         Cart cart = cartService.findCart(user.getUsername());
         Item item = itemService.findOne(cartItemDto.getItemId());
@@ -42,7 +42,6 @@ public class CartFacade {
     /**
      * 장바구니 상품 조회
      */
-    @Transactional(readOnly = true)
     public List<CartListDto> findCartItems(User user) {
         Cart cart = cartService.findCart(user.getUsername());
         List<CartItem> cartItems = cartItemService.findCartItemList(cart);

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -55,6 +55,22 @@ public class CartFacade {
         return toDto(cartItems, mainImages);
     }
 
+    /**
+     * 장바구니 상품 수량과 상품 재고 비교
+     */
+    public Boolean checkItemStock(CartItemDto cartItemDto) {
+        Item item = itemService.findOne(cartItemDto.getItemId());
+        return item.checkStock(cartItemDto.getQuantity());
+    }
+
+    /**
+     * 장바구니에 담을 상품 재고 조회
+     */
+    public int getItemStock(CartItemDto cartItemDto) {
+        Item item = itemService.findOne(cartItemDto.getItemId());
+        return item.getStockQuantity();
+    }
+
     public CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
         return CartItem.builder()
                 .cart(cart)

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -30,6 +30,7 @@ public class CartFacade {
     /**
      * 장바구니 상품 추가
      */
+    @Transactional
     public Long addCartItem(CartItemDto cartItemDto, User user) {
         Cart cart = cartService.findCart(user.getUsername());
         Item item = itemService.findOne(cartItemDto.getItemId());

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -70,7 +70,7 @@ public class CartFacade {
         return item.getStockQuantity();
     }
 
-    public CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
+    private CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
         return CartItem.builder()
                 .cart(cart)
                 .item(item)
@@ -78,7 +78,7 @@ public class CartFacade {
                 .build();
     }
 
-    public CartListDto toDto(CartItem cartItem, Image mainImage) {
+    private CartListDto toDto(CartItem cartItem, Image mainImage) {
         return CartListDto.builder()
                 .itemId(cartItem.getItemId())
                 .itemName(cartItem.getItemName())
@@ -88,7 +88,7 @@ public class CartFacade {
                 .build();
     }
 
-    public List<CartListDto> toDto(List<CartItem> cartItems, List<Image> mainImages) {
+    private List<CartListDto> toDto(List<CartItem> cartItems, List<Image> mainImages) {
         List<CartListDto> cartListDtos = new ArrayList<>();
 
         for (int i = 0; i < cartItems.size(); i++) {

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -34,7 +34,7 @@ public class CartItemService {
 
         // 상품이 이미 있을 경우, 개수 증가
         if (nonNull(savedCartItem)) {
-            savedCartItem.addCount(cartItem.getQuantity());
+            savedCartItem.addQuantity(cartItem.getQuantity());
             return savedCartItem.getId();
         }
 
@@ -66,7 +66,7 @@ public class CartItemService {
                 .orElseThrow(() -> new IllegalStateException("해당 장바구니 상품을 찾을 수 없습니다."));
 
         // 장바구니 상품의 수량 변경
-        cartItem.updateCount(count);
+        cartItem.updateQuantity(count);
     }
 
     /**

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -26,7 +26,7 @@ public class CartItemService {
     @Transactional
     public Long addCartItem(CartItem cartItem) {
         // 장바구니에 담을 상품 엔티티 조회
-        Item item = itemRepository.findById(cartItem.getItem().getId())
+        Item item = itemRepository.findById(cartItem.getItemId())
                 .orElseThrow(() -> new IllegalStateException("해당 상품을 찾을 수 없습니다."));
 
         // 장바구니에 해당 상품이 있는지 확인

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -5,7 +5,6 @@ import static java.util.Objects.nonNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.cart.entity.Cart;
 import shop.tryit.domain.cart.entity.CartItem;
 import shop.tryit.domain.cart.repository.CartItemRepository;
@@ -14,7 +13,6 @@ import shop.tryit.domain.item.repository.ItemRepository;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CartItemService {
 
     private final CartItemRepository cartItemRepository;
@@ -23,7 +21,6 @@ public class CartItemService {
     /**
      * 장바구니에 상품 추가
      */
-    @Transactional
     public Long addCartItem(CartItem cartItem) {
         // 장바구니에 담을 상품 엔티티 조회
         Item item = itemRepository.findById(cartItem.getItemId())
@@ -59,7 +56,6 @@ public class CartItemService {
     /**
      * 장바구니에 담긴 상품 수량 변경
      */
-    @Transactional
     public void updateCartItemCount(Long cartItemId, int count) {
         // 변경할 장바구니 상품 엔티티 조회
         CartItem cartItem = cartItemRepository.findById(cartItemId)
@@ -72,7 +68,6 @@ public class CartItemService {
     /**
      * 장바구니에 담긴 상품 삭제
      */
-    @Transactional
     public void deleteCartItem(Long cartItemId) {
         // 삭제할 장바구니 상품 엔티티 조회
         CartItem cartItem = cartItemRepository.findById(cartItemId)

--- a/src/main/java/shop/tryit/domain/item/entity/Item.java
+++ b/src/main/java/shop/tryit/domain/item/entity/Item.java
@@ -90,4 +90,9 @@ public class Item extends BaseTimeEntity {
         this.stockQuantity = restStock;
     }
 
+    // 상품 재고와 장바구니 수량 비교를 위한 로직
+    public boolean checkStock(int quantity) {
+        return stockQuantity > quantity;
+    }
+
 }

--- a/src/main/java/shop/tryit/web/cart/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/CartController.java
@@ -40,7 +40,7 @@ public class CartController {
         log.info("장바구니에 담을 상품의 수량 = {}", cartItemDto.getQuantity());
 
         // 상품 재고 검증
-        if (cartFacade.checkItemStock(cartItemDto)) {
+        if (Boolean.FALSE.equals(cartFacade.checkItemStock(cartItemDto))) {
             bindingResult.rejectValue("quantity", "StockError",
                     String.format("현재 남은 수량은 %d개 입니다.%n%d개 이하로 담아주세요.", cartFacade.getItemStock(cartItemDto), cartFacade.getItemStock(cartItemDto)));
         }

--- a/src/main/java/shop/tryit/web/cart/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/CartController.java
@@ -20,8 +20,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import shop.tryit.domain.cart.dto.CartItemDto;
 import shop.tryit.domain.cart.dto.CartListDto;
 import shop.tryit.domain.cart.service.CartFacade;
-import shop.tryit.domain.item.entity.Item;
-import shop.tryit.domain.item.service.ItemService;
 
 @Slf4j
 @Controller
@@ -30,7 +28,6 @@ import shop.tryit.domain.item.service.ItemService;
 public class CartController {
 
     private final CartFacade cartFacade;
-    private final ItemService itemService;
 
     /**
      * 장바구니에 상품 담기
@@ -42,12 +39,10 @@ public class CartController {
         log.info("장바구니에 담을 상품의 id = {}", cartItemDto.getItemId());
         log.info("장바구니에 담을 상품의 수량 = {}", cartItemDto.getQuantity());
 
-        Item item = itemService.findOne(cartItemDto.getItemId());
-
-        // TODO : if문 로직을 비즈니스 로직으로 분리
-        // 수량 검증
-        if (item.getStockQuantity() < cartItemDto.getQuantity()) {
-            bindingResult.rejectValue("quantity", "StockError", String.format("현재 남은 수량은 %d개 입니다.%n%d개 이하로 담아주세요.", item.getStockQuantity(), item.getStockQuantity()));
+        // 상품 재고 검증
+        if (cartFacade.checkItemStock(cartItemDto)) {
+            bindingResult.rejectValue("quantity", "StockError",
+                    String.format("현재 남은 수량은 %d개 입니다.%n%d개 이하로 담아주세요.", cartFacade.getItemStock(cartItemDto), cartFacade.getItemStock(cartItemDto)));
         }
 
         // 검증 실패시 400


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 관련 리팩토링

## 📋 작업사항
- 장바구니 컨트롤러에서 장바구니 상품 담기 검증에 사용되는 로직을 비즈니스 로직으로 분리
- `Facade`에서 dto<-entity 변환 기능으로 사용되는 메소드의 접근지시자를 `private`으로 수정

- 동일 상품을 장바구니에 담을 때 장바구니 수량 증가가 일어나지 않는 이슈
   - `Facade`에 적용되어 있는 트랜잭션이 `Service`까지 영향을 주는 것으로 확인
   - `Service`에 적용되는 트랜잭션을 모두 지우고, `Facade`에서만 적용되도록 수정
   
