### PR TITLE
feat: 장바구니 목록에서 수량 변경 처리

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/dto/CartListDto.java
+++ b/src/main/java/shop/tryit/domain/cart/dto/CartListDto.java
@@ -10,6 +10,8 @@ import shop.tryit.domain.item.entity.Image;
 @NoArgsConstructor
 public class CartListDto {
 
+    private Long cartItemId; // 장바구니 상품 ID
+
     private Long itemId; // 상품 ID
 
     private String itemName; // 상품 이름
@@ -23,7 +25,8 @@ public class CartListDto {
     private int totalPrice; // 상품 금액 * 수량
 
     @Builder
-    private CartListDto(Long itemId, String itemName, int itemPrice, int quantity, Image mainImage) {
+    private CartListDto(Long cartItemId, Long itemId, String itemName, int itemPrice, int quantity, Image mainImage) {
+        this.cartItemId = cartItemId;
         this.itemId = itemId;
         this.itemName = itemName;
         this.itemPrice = itemPrice;

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -71,6 +71,14 @@ public class CartFacade {
         return item.getStockQuantity();
     }
 
+    /**
+     * 장바구니 상품 수량 변경
+     */
+    @Transactional
+    public Long updateCartItemQuantity(Long cartItemId, int newQuantity) {
+        return cartItemService.updateCartItemQuantity(cartItemId, newQuantity);
+    }
+
     private CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
         return CartItem.builder()
                 .cart(cart)

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -81,6 +81,7 @@ public class CartFacade {
 
     private CartListDto toDto(CartItem cartItem, Image mainImage) {
         return CartListDto.builder()
+                .cartItemId(cartItem.getId())
                 .itemId(cartItem.getItemId())
                 .itemName(cartItem.getItemName())
                 .itemPrice(cartItem.getItemPrice())

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -56,13 +56,15 @@ public class CartItemService {
     /**
      * 장바구니에 담긴 상품 수량 변경
      */
-    public void updateCartItemQuantity(Long cartItemId, int quantity) {
+    public Long updateCartItemQuantity(Long cartItemId, int quantity) {
         // 변경할 장바구니 상품 엔티티 조회
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new IllegalStateException("해당 장바구니 상품을 찾을 수 없습니다."));
 
         // 장바구니 상품의 수량 변경
         cartItem.updateQuantity(quantity);
+
+        return cartItemId;
     }
 
     /**

--- a/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartItemService.java
@@ -56,13 +56,13 @@ public class CartItemService {
     /**
      * 장바구니에 담긴 상품 수량 변경
      */
-    public void updateCartItemCount(Long cartItemId, int count) {
+    public void updateCartItemQuantity(Long cartItemId, int quantity) {
         // 변경할 장바구니 상품 엔티티 조회
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new IllegalStateException("해당 장바구니 상품을 찾을 수 없습니다."));
 
         // 장바구니 상품의 수량 변경
-        cartItem.updateQuantity(count);
+        cartItem.updateQuantity(quantity);
     }
 
     /**

--- a/src/main/java/shop/tryit/web/cart/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/CartController.java
@@ -14,8 +14,10 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import shop.tryit.domain.cart.dto.CartItemDto;
 import shop.tryit.domain.cart.dto.CartListDto;
@@ -72,12 +74,12 @@ public class CartController {
 
         return "/carts/list";
     }
-//
-//    /**
-//     * 장바구니에 담긴 상품 수량 변경
-//     */
-//
-//    /**
-//     * 장바구니에 담긴 상품 삭제
-//     */
-}
+
+    /**
+     * 장바구니에 담긴 상품 수량 변경
+     */
+    @PostMapping("/{cartItemId}/update")
+    public @ResponseBody ResponseEntity<String> update(@PathVariable Long cartItemId, @RequestParam int newQuantity) {
+        cartFacade.updateCartItemQuantity(cartItemId, newQuantity);
+        return ResponseEntity.ok("cartItem quantity update success");
+    }

--- a/src/main/resources/templates/carts/list.html
+++ b/src/main/resources/templates/carts/list.html
@@ -28,7 +28,7 @@
         <thead>
         <tr class="text-center">
           <th>
-            <input type="checkbox" id="check-all">
+            <input type="checkbox" checked="checked" id="check-all">
           </th>
           <th>이미지</th>
           <th class="text-left">상품정보</th>
@@ -42,7 +42,7 @@
         <tbody>
         <tr class="text-center" th:each="cartListDto : ${cartListDtos}">
           <td class="cart-info">
-            <input type="checkbox" id="check-box">
+            <input type="checkbox" checked="checked" id="check-box">
             <input type="hidden" id="individual-itemId" th:value="${cartListDto.itemId}">
             <input type="hidden" id="individual-quantity" th:value="${cartListDto.quantity}">
             <input type="hidden" id="individual-totalPrice" th:value="${cartListDto.totalPrice}">

--- a/src/main/resources/templates/carts/list.html
+++ b/src/main/resources/templates/carts/list.html
@@ -57,8 +57,10 @@
             <span th:text="${cartListDto.itemPrice}"></span>원
           </td>
           <td>
-            <label for="quantity"></label>
-            <input type="number" id="quantity" min="1" th:value="${cartListDto.quantity}">
+            <input type="number"
+                   th:id="'quantity_' + ${cartListDto.cartItemId}"
+                   th:value="${cartListDto.quantity}" min="1"
+                   onchange="updateQuantity(this)">
           </td>
           <td>
             <span th:text="${cartListDto.totalPrice}"></span>원
@@ -156,6 +158,28 @@
     $(".order-form").html(formData);
     $(".order-form").submit();
   });
+
+  /* 장바구니에서 상품 수량 변경 */
+  function updateQuantity(obj) {
+    let data = { newQuantity : obj.value}
+    console.log(data);
+
+    let cartItemId = obj.id.split('_')[1];
+    let url = "/carts/" + cartItemId + "/update";
+    
+    $.ajax({
+      url    : url,
+      type   : "POST",
+      data   : data,
+      success: function(result) {
+        console.log("장바구니 수량 변경 성공");
+        location.href="/carts";
+      },
+      error  : function(jqXHR) {
+        alert(jqXHR.responseText);
+      }
+    });
+  }
 </script>
 </body>
 

--- a/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
+++ b/src/test/java/shop/tryit/domain/cart/CartItemServiceTests.java
@@ -114,7 +114,7 @@ class CartItemServiceTests {
         cartItemJpaRepository.save(cartItem);
 
         // when
-        sut.updateCartItemCount(cartItem.getId(), 5);
+        sut.updateCartItemQuantity(cartItem.getId(), 5);
 
         // then
         assertThat(cartItem.getQuantity()).isEqualTo(5);


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 목록에서 수량 변경 처리

## 📋 작업사항
- CartListDto에 cartItemId 멤버변수 추가
- CartFacade에 장바구니 상품 수량을 변경하는 기능 추가
- 장바구니 폼에서 수량 버튼 조작 시 장바구니 상품 수량 변경을 요청하는 js 추가
- 장바구니 상품 수량 변경 요청을 받는 컨트롤러 추가
- 처음에 체크박스가 모두 체크되어 있도록 checked 속성 추가

## 💬 추가사항
- 장바구니에서 수량 버튼 조작으로 DB에 데이터 변경이 일어난뒤, 상품 개별 합계와 결제 예정 금액 변경이 새로고침을 통해 일어나는데 이때 체크박스 체크 유무까지 같이 초기화 되기 때문에 추후 js 리팩토링이 필요