### PR TITLE
feat: 장바구니 목록에서 삭제 버튼 처리

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -79,6 +79,14 @@ public class CartFacade {
         return cartItemService.updateCartItemQuantity(cartItemId, newQuantity);
     }
 
+    /**
+     * 장바구니 상품 삭제
+     */
+    @Transactional
+    public void deleteCartItem(Long cartItemId) {
+        cartItemService.deleteCartItem(cartItemId);
+    }
+
     private CartItem toEntity(CartItemDto cartItemDto, Item item, Cart cart) {
         return CartItem.builder()
                 .cart(cart)

--- a/src/main/java/shop/tryit/web/cart/CartController.java
+++ b/src/main/java/shop/tryit/web/cart/CartController.java
@@ -88,4 +88,13 @@ public class CartController {
         return ResponseEntity.ok("cartItem quantity update success");
     }
 
+    /**
+     * 장바구니에 담긴 상품 삭제
+     */
+    @PostMapping("/{cartItemId}/delete")
+    public @ResponseBody ResponseEntity<String> delete(@PathVariable Long cartItemId) {
+        cartFacade.deleteCartItem(cartItemId);
+        return ResponseEntity.ok("cartItem delete success");
+    }
+
 }

--- a/src/main/resources/templates/carts/list.html
+++ b/src/main/resources/templates/carts/list.html
@@ -68,7 +68,11 @@
             </span>원
           </td>
           <td>
-            <button type="button" class="btn btn-custom btn-sm">삭제</button>
+            <button type="button" class="btn btn-custom btn-sm" 
+                    onclick="deleteCartItem(this)" 
+                    th:value="${cartListDto.cartItemId}">
+              삭제
+            </button>
           </td>
         </tr>
         </tbody>
@@ -196,6 +200,23 @@
     updateQuantity(cartItemId, newQuantity);
   };
 
+  /* 장바구니 상품 삭제 요청*/
+  function deleteCartItem(obj) {
+    let cartItemId = obj.value;
+    let url = "/carts/" + cartItemId + "/delete";
+
+    $.ajax({
+      url    : url,
+      type   : "POST",
+      success: function(result) {
+        console.log("장바구니 상품 삭제 성공");
+        location.href = "/carts"; // 새로고침
+      },
+      error  : function(jqXHR) {
+        alert(jqXHR.responseText);
+      }
+    });
+  };
 </script>
 </body>
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니 목록 페이지에서 삭제 버튼 클릭 시 장바구니에서 해당 상품이 삭제되도록 개발

## 📋 작업사항
- `CartFacade`에 장바구니 상품 삭제 기능 추가
- 장바구니 목록 폼에 서버로 장바구니 상품 삭제 요청을 보내는 js 추가
- 장바구니 상품 삭제 요청을 받는 컨트롤러 추가