### PR TITLE
refactor: 장바구니에서 상품의 재고보다 많은 수량을 주문할 수 없도록 검증 처리

### DIFF
--- a/src/main/java/shop/tryit/domain/cart/dto/CartListDto.java
+++ b/src/main/java/shop/tryit/domain/cart/dto/CartListDto.java
@@ -22,14 +22,17 @@ public class CartListDto {
 
     private Image mainImage; // 상품 메인이미지
 
+    private int itemStock; // 상품 재고
+
     @Builder
-    private CartListDto(Long cartItemId, Long itemId, String itemName, int itemPrice, int quantity, Image mainImage) {
+    private CartListDto(Long cartItemId, Long itemId, String itemName, int itemPrice, int quantity, Image mainImage, int itemStock) {
         this.cartItemId = cartItemId;
         this.itemId = itemId;
         this.itemName = itemName;
         this.itemPrice = itemPrice;
         this.quantity = quantity;
         this.mainImage = mainImage;
+        this.itemStock = itemStock;
     }
 
 }

--- a/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
+++ b/src/main/java/shop/tryit/domain/cart/entity/CartItem.java
@@ -54,6 +54,10 @@ public class CartItem {
         return item.getPrice();
     }
 
+    public int getItemStock() {
+        return item.getStockQuantity();
+    }
+
     /**
      * 비즈니스 로직
      **/

--- a/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
+++ b/src/main/java/shop/tryit/domain/cart/service/CartFacade.java
@@ -103,6 +103,7 @@ public class CartFacade {
                 .itemPrice(cartItem.getItemPrice())
                 .quantity(cartItem.getQuantity())
                 .mainImage(mainImage)
+                .itemStock(cartItem.getItemStock())
                 .build();
     }
 

--- a/src/main/resources/templates/carts/list.html
+++ b/src/main/resources/templates/carts/list.html
@@ -58,8 +58,8 @@
           </td>
           <td>
             <span th:id="'itemPrice_' + ${cartListDto.cartItemId}"
-                  th:value="${cartListDto.itemPrice}"
-                  th:text="${cartListDto.itemPrice}"></span>원
+                  th:text="${cartListDto.itemPrice}">
+            </span>원
           </td>
           <td>
             <input type="number"

--- a/src/main/resources/templates/carts/list.html
+++ b/src/main/resources/templates/carts/list.html
@@ -44,13 +44,18 @@
           <td>
             <input type="checkbox" checked="checked" id="check-box" th:value="${cartListDto.cartItemId}">
             <input type="hidden" th:id="'itemId_' + ${cartListDto.cartItemId}" th:value="${cartListDto.itemId}">
+            <input type="hidden" th:id="'itemStock_' + ${cartListDto.cartItemId}" th:value="${cartListDto.itemStock}">
           </td>
           <td>
             <a th:href="@{/items/{id}(id=${cartListDto.itemId})}">
               <img th:src="|/files/${cartListDto.mainImage.getStoreFileName()}|" width="100" height="100"/>
             </a>
           </td>
-          <td th:text="${cartListDto.itemName}"></td>
+          <td>
+            <span th:id="'itemName_' + ${cartListDto.cartItemId}"
+                  th:text="${cartListDto.itemName}">
+            </span>
+          </td>
           <td>
             <span th:id="'itemPrice_' + ${cartListDto.cartItemId}"
                   th:value="${cartListDto.itemPrice}"
@@ -145,11 +150,21 @@
   $("#order-btn").click(function() {
     let formData = "";
     let idx = 0;
+    let isEnoughStock = true;
 
     $("input:checkbox[id=check-box]:checked").each(function() {
       let cartItemId = $(this).val();
       let itemId = $("#itemId_" + cartItemId).val();
       let quantity = $("#quantity_" + cartItemId).val();
+      let itemStock = $("#itemStock_" + cartItemId).val();
+      let itemName = $("#itemName_" + cartItemId).text();
+
+      // 상품 재고가 충분한지 확인
+      if (parseInt(itemStock) < parseInt(quantity)) {
+        alert(itemName + "의 재고가 부족합니다. 수량을 변경해주세요. \n❗ 현재 재고 : " + itemStock + "개");
+        isEnoughStock = false;
+        return false; // 반복문 탈출
+      };
 
       let itemId_input = '<input type="hidden" name="payments[' + idx + '].itemId" value="' + itemId + '">';
       formData += itemId_input;
@@ -160,9 +175,9 @@
       idx += 1;
     });
 
-    if (formData == "") {
+    if (isEnoughStock == true && formData == "") {
       alert("선택된 상품이 없습니다.");
-    } else {
+    } else if (isEnoughStock == true) {
       $(".order-form").html(formData);
       $(".order-form").submit();
     };


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 장바구니에서 상품의 재고보다 많은 수량을 주문할 수 없도록 프론트 측에서 검증을 진행

## 📋 작업사항
- `CartListDto`에 `itemStock` 멤버변수를 추가해 뷰에 전달
- `CartItem` 엔티티에 상품 재고를 반환하는 `getItemStock()` 추가
- 장바구니에서 주문하려는 수량만큼 상품의 재고가 충분한지 확인하는 조건문 추가
