### PR TITLE
refactor: 본인 및 관리자 제외시 게시글 수정 막기 기능 추가

### DIFF
--- a/src/main/java/shop/tryit/web/qna/QuestionController.java
+++ b/src/main/java/shop/tryit/web/qna/QuestionController.java
@@ -86,9 +86,14 @@ public class QuestionController {
     }
 
     @GetMapping("/{questionId}/update")
-    public String updateForm(@PathVariable Long questionId, Model model) {
-        model.addAttribute("questionFormDto", qnAFacade.toDto(questionId));
+    public String updateForm(@PathVariable Long questionId,
+                             Model model,
+                             @AuthenticationPrincipal User user) {
+        if (!qnAFacade.checkDeleteQuestion(questionId, user)) {
+            return String.format("redirect:/qna/%s", questionId);
+        }
 
+        model.addAttribute("questionFormDto", qnAFacade.toDto(questionId));
         return "qna/update";
     }
 


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 본인 및 관리자 제외시 게시글 수정 막기 기능 추가
  -  본인 및 관리자가 아닌 사람이 게시글 수정 버튼 클릭시 작동이 안되도록 구현 

